### PR TITLE
[Enhancement] You can now generate a migration along with your new model

### DIFF
--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -27,7 +27,7 @@ class CrudModelBackpackCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $description = 'Generate a Backpack CRUD model';
+    protected $description = 'Generate a Backpack CRUD model and migration';
 
     /**
      * The type of class being generated.
@@ -99,5 +99,22 @@ class CrudModelBackpackCommand extends GeneratorCommand
         return [
 
         ];
+    }
+
+    protected function buildMigration($name)
+    {
+        \Artisan::call('make:migration', [
+            'name' => 'create_' . snake_case($name) . '_table',
+            '--create' => camel_case($name)
+        ]);
+    }
+
+    public function handle()
+    {
+        $name = $this->argument('name');
+
+        if (!$this->option('nomigration')) {
+            $this->buildMigration($name);
+        }
     }
 }

--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -104,8 +104,8 @@ class CrudModelBackpackCommand extends GeneratorCommand
     protected function buildMigration($name)
     {
         \Artisan::call('make:migration', [
-            'name' => 'create_' . snake_case($name) . '_table',
-            '--create' => camel_case($name)
+            'name' => 'create_'.snake_case($name).'_table',
+            '--create' => camel_case($name),
         ]);
     }
 
@@ -113,7 +113,7 @@ class CrudModelBackpackCommand extends GeneratorCommand
     {
         $name = $this->argument('name');
 
-        if (!$this->option('nomigration')) {
+        if (! $this->option('nomigration')) {
             $this->buildMigration($name);
         }
     }

--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -18,7 +18,9 @@ class CrudModelBackpackCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'backpack:crud-model {name}';
+    protected $signature = 'backpack:crud-model
+                            {name : Name of the model}
+                            {--nomigration : Disables creating of the migration file}';
 
     /**
      * The console command description.

--- a/src/Console/Commands/ModelBackpackCommand.php
+++ b/src/Console/Commands/ModelBackpackCommand.php
@@ -109,8 +109,8 @@ class ModelBackpackCommand extends GeneratorCommand
     protected function buildMigration($name)
     {
         \Artisan::call('make:migration', [
-            'name' => 'create_' . snake_case($name) . '_table',
-            '--create' => camel_case($name)
+            'name' => 'create_'.snake_case($name).'_table',
+            '--create' => camel_case($name),
         ]);
 
         if ($this->option('softdelete')) {
@@ -125,7 +125,7 @@ class ModelBackpackCommand extends GeneratorCommand
     {
         $name = $this->argument('name');
 
-        if (!$this->option('nomigration')) {
+        if (! $this->option('nomigration')) {
             $this->buildMigration($name);
         }
     }


### PR DESCRIPTION
Now creates a migration with the new model command,

You can skip migration creation with `--nomigration`

e.g

`php artisan backpack:crud-model LemonCake` or without migration `php artisan backpack:crud-model LemonCake --nomigration`