### PR TITLE
Fixes #13 - Allows you to publish buttons/fields/columns

### DIFF
--- a/src/Console/Commands/CrudOverwrite.php
+++ b/src/Console/Commands/CrudOverwrite.php
@@ -73,14 +73,14 @@ class CrudOverwrite extends Command
 
     protected function processPublish($file, $label)
     {
-        $sourceFile = $this->packageDir. $file . '.blade.php';
-        $copiedFile = $this->appDir . $file . '.blade.php';
+        $sourceFile = $this->packageDir.$file.'.blade.php';
+        $copiedFile = $this->appDir.$file.'.blade.php';
 
-        if (!file_exists($sourceFile)) {
+        if (! file_exists($sourceFile)) {
             return $this->error(
-                'Cannot find source ' . $label . ' at '
-                . $sourceFile .
-                ' - make sure you\'ve picked a real ' . $label . ' type'
+                'Cannot find source '.$label.' at '
+                .$sourceFile.
+                ' - make sure you\'ve picked a real '.$label.' type'
             );
         } else {
             $canCopy = true;
@@ -88,7 +88,7 @@ class CrudOverwrite extends Command
             if (file_exists($copiedFile)) {
                 $canCopy = $this->confirm(
                     'File already exists at '
-                    . $copiedFile .
+                    .$copiedFile.
                     ' - do you want to overwrite it?'
                 );
             }
@@ -96,7 +96,7 @@ class CrudOverwrite extends Command
             if ($canCopy) {
                 $path = pathinfo($copiedFile);
 
-                if (!file_exists($path['dirname'])) {
+                if (! file_exists($path['dirname'])) {
                     mkdir($path['dirname'], 0755, true);
                 }
 
@@ -105,9 +105,9 @@ class CrudOverwrite extends Command
                 } else {
                     return $this->error(
                         'Failed to copy '
-                        . $sourceFile .
+                        .$sourceFile.
                         ' to '
-                        . $copiedFile .
+                        .$copiedFile.
                         ' for unknown reason'
                     );
                 }
@@ -117,16 +117,16 @@ class CrudOverwrite extends Command
 
     protected function publishField()
     {
-        return $this->processPublish('fields/' . $this->name, 'field');
+        return $this->processPublish('fields/'.$this->name, 'field');
     }
 
     protected function publishColumn()
     {
-        return $this->processPublish('columns/' . $this->name, 'column');
+        return $this->processPublish('columns/'.$this->name, 'column');
     }
 
     protected function publishButton()
     {
-        return $this->processPublish('buttons/' . $this->name, 'button');
+        return $this->processPublish('buttons/'.$this->name, 'button');
     }
 }

--- a/src/Console/Commands/CrudOverwrite.php
+++ b/src/Console/Commands/CrudOverwrite.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class CrudOverwrite extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'backpack:overwrite';
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backpack:overwrite
+                            {type : what are you overwriting? field/column/button}
+                            {name : name of the field}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Publishes a built in field/column/button for modification';
+
+    public $packageDir = 'vendor/backpack/crud/src/resources/views/';
+    public $appDir = 'resources/views/vendor/backpack/crud/';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->type = strtolower($this->argument('type'));
+        $this->name = strtolower($this->argument('name'));
+
+        switch ($this->type) {
+            case 'field':
+            case 'fields':
+                return $this->publishField();
+            break;
+            case 'button':
+            case 'buttons':
+                return $this->publishButton();
+            break;
+            case 'column':
+            case 'columns':
+                return $this->publishColumn();
+            break;
+            default:
+                return $this->error('Please pick from field, column or button');
+            break;
+        }
+    }
+
+    protected function processPublish($file, $label)
+    {
+        $sourceFile = $this->packageDir. $file . '.blade.php';
+        $copiedFile = $this->appDir . $file . '.blade.php';
+
+        if (!file_exists($sourceFile)) {
+            return $this->error(
+                'Cannot find source ' . $label . ' at '
+                . $sourceFile .
+                ' - make sure you\'ve picked a real ' . $label . ' type'
+            );
+        } else {
+            $canCopy = true;
+
+            if (file_exists($copiedFile)) {
+                $canCopy = $this->confirm(
+                    'File already exists at '
+                    . $copiedFile .
+                    ' - do you want to overwrite it?'
+                );
+            }
+
+            if ($canCopy) {
+                $path = pathinfo($copiedFile);
+
+                if (!file_exists($path['dirname'])) {
+                    mkdir($path['dirname'], 0755, true);
+                }
+
+                if (copy($sourceFile, $copiedFile)) {
+                    $this->info('Copied to '.$copiedFile);
+                } else {
+                    return $this->error(
+                        'Failed to copy '
+                        . $sourceFile .
+                        ' to '
+                        . $copiedFile .
+                        ' for unknown reason'
+                    );
+                }
+            }
+        }
+    }
+
+    protected function publishField()
+    {
+        return $this->processPublish('fields/' . $this->name, 'field');
+    }
+
+    protected function publishColumn()
+    {
+        return $this->processPublish('columns/' . $this->name, 'column');
+    }
+
+    protected function publishButton()
+    {
+        return $this->processPublish('buttons/' . $this->name, 'button');
+    }
+}

--- a/src/GeneratorsServiceProvider.php
+++ b/src/GeneratorsServiceProvider.php
@@ -16,6 +16,7 @@ class GeneratorsServiceProvider extends ServiceProvider
         'Backpack\Generators\Console\Commands\CrudControllerBackpackCommand',
         'Backpack\Generators\Console\Commands\CrudRequestBackpackCommand',
         'Backpack\Generators\Console\Commands\CrudBackpackCommand',
+        'Backpack\Generators\Console\Commands\CrudOverwrite',
     ];
 
     /**


### PR DESCRIPTION
Copies a version of the package view into your local resources folder for modification

# Usage e.g

```sh
php artisan backpack:overwrite field select2
php artisan backpack:overwrite field array

php artisan backpack:overwrite button create
php artisan backpack:overwrite button edit

php artisan backpack:overwrite column boolean
php artisan backpack:overwrite column image
```