### PR TITLE
Using str_plural() instead of appending s

### DIFF
--- a/src/Console/Commands/CrudControllerBackpackCommand.php
+++ b/src/Console/Commands/CrudControllerBackpackCommand.php
@@ -80,7 +80,7 @@ class CrudControllerBackpackCommand extends GeneratorCommand
      */
     protected function replaceNameStrings(&$stub, $name)
     {
-        $table = ltrim(strtolower(preg_replace('/[A-Z]/', '_$0', str_replace($this->getNamespace($name).'\\', '', $name))), '_').'s';
+        $table = str_plural(ltrim(strtolower(preg_replace('/[A-Z]/', '_$0', str_replace($this->getNamespace($name).'\\', '', $name))), '_'));
 
         $stub = str_replace('DummyTable', $table, $stub);
         $stub = str_replace('dummy_class', strtolower(str_replace($this->getNamespace($name).'\\', '', $name)), $stub);


### PR DESCRIPTION
This should solve issues with resources such as "category" (which is currently expanded to "categorys") in CRUD Controller's setUp() method built from stub.