### PR TITLE
Remove backslash in command description

### DIFF
--- a/src/Console/Commands/CrudRequestBackpackCommand.php
+++ b/src/Console/Commands/CrudRequestBackpackCommand.php
@@ -25,7 +25,7 @@ class CrudRequestBackpackCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $description = 'Generate a Backpack\CRUD request';
+    protected $description = 'Generate a Backpack CRUD request';
 
     /**
      * The type of class being generated.


### PR DESCRIPTION
Remove slash in  description command

<img width="467" alt="typo" src="https://cloud.githubusercontent.com/assets/793514/21966847/259ec594-db5a-11e6-9be1-8102dcfcba8f.png">

