### PR TITLE
Controller stub should respect the admin prefix from config

### DIFF
--- a/src/Console/stubs/crud-controller.stub
+++ b/src/Console/stubs/crud-controller.stub
@@ -20,7 +20,7 @@ class DummyClassCrudController extends CrudController
         |--------------------------------------------------------------------------
         */
         $this->crud->setModel("App\Models\DummyClass");
-        $this->crud->setRoute("admin/dummy_class");
+        $this->crud->setRoute(config('backpack.base.route_prefix') . '/dummy_class');
         $this->crud->setEntityNameStrings('dummy_class', 'DummyTable');
 
         /*


### PR DESCRIPTION
We should not hardcode `admin` prefix here, we should use the one specified in config by default.