### PR TITLE
Getting rid of the escaping in the model name

### DIFF
--- a/src/Console/stubs/crud-controller.stub
+++ b/src/Console/stubs/crud-controller.stub
@@ -19,8 +19,8 @@ class DummyClassCrudController extends CrudController
         | BASIC CRUD INFORMATION
         |--------------------------------------------------------------------------
         */
-        $this->crud->setModel("App\Models\DummyClass");
-        $this->crud->setRoute("admin/dummy_class");
+        $this->crud->setModel('App\Models\DummyClass');
+        $this->crud->setRoute('admin/dummy_class');
         $this->crud->setEntityNameStrings('dummy_class', 'DummyTable');
 
         /*


### PR DESCRIPTION
Change of double quotes to single quotes in the method setModel() in the generator. Since the model name is specified with a namespace (which contain a backslash), this is recognized by many editors as escaping (for example PhpStorm). Using single quotes allows you to get rid of this.

![2017 03 17](https://cloud.githubusercontent.com/assets/3229523/24044382/19b90eea-0b2c-11e7-967e-d491fc62f28b.png)
