### PR TITLE
Fix generated table names for models

### DIFF
--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\Generators\Console\Commands;
 
+use Illuminate\Support\Str;
 use Illuminate\Console\GeneratorCommand;
 
 class CrudModelBackpackCommand extends GeneratorCommand
@@ -66,7 +67,9 @@ class CrudModelBackpackCommand extends GeneratorCommand
      */
     protected function replaceTable(&$stub, $name)
     {
-        $table = ltrim(strtolower(preg_replace('/[A-Z]/', '_$0', str_replace($this->getNamespace($name).'\\', '', $name))), '_').'s';
+        $name = ltrim(strtolower(preg_replace('/[A-Z]/', '_$0', str_replace($this->getNamespace($name).'\\', '', $name))), '_');
+
+        $table = Str::snake(Str::plural($name));
 
         $stub = str_replace('DummyTable', $table, $stub);
 

--- a/src/Console/Commands/ModelBackpackCommand.php
+++ b/src/Console/Commands/ModelBackpackCommand.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\Generators\Console\Commands;
 
+use Illuminate\Support\Str;
 use Illuminate\Console\GeneratorCommand;
 
 class ModelBackpackCommand extends GeneratorCommand
@@ -70,7 +71,9 @@ class ModelBackpackCommand extends GeneratorCommand
      */
     protected function replaceTable(&$stub, $name)
     {
-        $table = ltrim(strtolower(preg_replace('/[A-Z]/', '_$0', str_replace($this->getNamespace($name).'\\', '', $name))), '_').'s';
+        $name = ltrim(strtolower(preg_replace('/[A-Z]/', '_$0', str_replace($this->getNamespace($name).'\\', '', $name))), '_');
+
+        $table = Str::snake(Str::plural($name));
 
         $stub = str_replace('DummyTable', $table, $stub);
 


### PR DESCRIPTION
When running an artisan command to generate a model, we sometimes get a wrong plural name for the table, for example:
```php artisan backpack:crud-model currency```

Will result with:
```protected $table = 'currencys';```

We now use Laravel's pluralizer instead.