### PR TITLE
removed unnecessary space from model.stub

### DIFF
--- a/src/Console/stubs/model.stub
+++ b/src/Console/stubs/model.stub
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class DummyClass extends Model
 {
-     /*
+    /*
     |--------------------------------------------------------------------------
     | GLOBAL VARIABLES
     |--------------------------------------------------------------------------


### PR DESCRIPTION
for some reason with this space I wasn't able to align `public $timestamps = false;` under `protected $primaryKey = 'id';` correctly 
![capture d ecran 2018-03-04 a 02 57 40](https://user-images.githubusercontent.com/1247248/36941278-e66b8108-1f57-11e8-9555-735da382ddf0.png)
