### PR TITLE
use backpack_auth() function from 0.9.x updates

### DIFF
--- a/src/Console/stubs/crud-request.stub
+++ b/src/Console/stubs/crud-request.stub
@@ -15,7 +15,7 @@ class DummyClassRequest extends FormRequest
     public function authorize()
     {
         // only allow updates if the user is logged in
-        return \Auth::check();
+        return backpack_auth()->check();
     }
 
     /**


### PR DESCRIPTION
this is a break changing commit ( if user uses old Base version this will cause problems  ) 
i would like to use \Auth::guard('admin')->check(); but they may uses another guard name for an admin panel.