### PR TITLE
Fix Advanced Queries Example

### DIFF
--- a/src/Console/stubs/crud-controller.stub
+++ b/src/Console/stubs/crud-controller.stub
@@ -91,7 +91,7 @@ class DummyClassCrudController extends CrudController
         // ------ ADVANCED QUERIES
         // $this->crud->addClause('active');
         // $this->crud->addClause('type', 'car');
-        // $this->crud->addClause('where', 'name', '==', 'car');
+        // $this->crud->addClause('where', 'name', '=', 'car');
         // $this->crud->addClause('whereName', 'car');
         // $this->crud->addClause('whereHas', 'posts', function($query) {
         //     $query->activePosts();


### PR DESCRIPTION
Query should have just one "=" and not 2 of it