### PR TITLE
Rename make commands

### DIFF
--- a/src/Console/Commands/CrudBackpackCommand.php
+++ b/src/Console/Commands/CrudBackpackCommand.php
@@ -12,7 +12,7 @@ class CrudBackpackCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'backpack:crud {name}';
+    protected $signature = 'backpack:make:crud {name}';
 
     /**
      * The console command description.

--- a/src/Console/Commands/CrudControllerBackpackCommand.php
+++ b/src/Console/Commands/CrudControllerBackpackCommand.php
@@ -18,7 +18,7 @@ class CrudControllerBackpackCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'backpack:make:crud-controller {name}';
+    protected $signature = 'backpack:make:controller {name}';
 
     /**
      * The console command description.

--- a/src/Console/Commands/CrudControllerBackpackCommand.php
+++ b/src/Console/Commands/CrudControllerBackpackCommand.php
@@ -11,14 +11,14 @@ class CrudControllerBackpackCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $name = 'backpack:crud-controller';
+    protected $name = 'backpack:make:controller';
 
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'backpack:crud-controller {name}';
+    protected $signature = 'backpack:make:crud-controller {name}';
 
     /**
      * The console command description.

--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -19,7 +19,7 @@ class CrudModelBackpackCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'backpack:make:model {name}';
+    protected $signature = 'backpack:make:crud-model {name}';
 
     /**
      * The console command description.

--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -12,14 +12,14 @@ class CrudModelBackpackCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $name = 'backpack:crud-model';
+    protected $name = 'backpack:make:model';
 
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'backpack:crud-model {name}';
+    protected $signature = 'backpack:make:model {name}';
 
     /**
      * The console command description.

--- a/src/Console/Commands/CrudRequestBackpackCommand.php
+++ b/src/Console/Commands/CrudRequestBackpackCommand.php
@@ -18,7 +18,7 @@ class CrudRequestBackpackCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'backpack:make:request {name}';
+    protected $signature = 'backpack:make:crud-request {name}';
 
     /**
      * The console command description.

--- a/src/Console/Commands/CrudRequestBackpackCommand.php
+++ b/src/Console/Commands/CrudRequestBackpackCommand.php
@@ -11,14 +11,14 @@ class CrudRequestBackpackCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $name = 'backpack:crud-request';
+    protected $name = 'backpack:make:request';
 
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'backpack:crud-request {name}';
+    protected $signature = 'backpack:make:request {name}';
 
     /**
      * The console command description.

--- a/src/Console/Commands/ModelBackpackCommand.php
+++ b/src/Console/Commands/ModelBackpackCommand.php
@@ -12,14 +12,14 @@ class ModelBackpackCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $name = 'backpack:model';
+    protected $name = 'backpack:make:model';
 
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'backpack:model {name} {--softdelete}';
+    protected $signature = 'backpack:make:model {name} {--softdelete}';
 
     /**
      * The console command description.

--- a/src/Console/Commands/RequestBackpackCommand.php
+++ b/src/Console/Commands/RequestBackpackCommand.php
@@ -11,14 +11,14 @@ class RequestBackpackCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $name = 'backpack:request';
+    protected $name = 'backpack:make:request';
 
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'backpack:request {name}';
+    protected $signature = 'backpack:make:request {name}';
 
     /**
      * The console command description.

--- a/src/Console/Commands/ViewBackpackCommand.php
+++ b/src/Console/Commands/ViewBackpackCommand.php
@@ -11,14 +11,14 @@ class ViewBackpackCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $name = 'backpack:view';
+    protected $name = 'backpack:make:view';
 
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'backpack:view {name} {--plain}';
+    protected $signature = 'backpack:make:view {name} {--plain}';
 
     /**
      * The console command description.


### PR DESCRIPTION
Renaming Backpack generator commands to follow more accurate Laravel schema:

```
backpack:crud-> backpack:make:crud
backpack:crud-controller -> backpack:make:controller
backpack:crud-model -> backpack:make:crud-model
backpack:crud-request-> backpack:make:crud-request
backpack:model -> backpack:make:model
backpack:request -> backpack:make:request
backpack:view -> backpack:make:view
```

I know it is a little longer to type, however I feel that it sticks with standard laravel console schema better and clarifies what it does better.