### PR TITLE
Remove Ajax as commented documentation in controller stub

### DIFF
--- a/src/Console/stubs/crud-controller.stub
+++ b/src/Console/stubs/crud-controller.stub
@@ -80,15 +80,8 @@ class DummyClassCrudController extends CrudController
         // Please check out: https://laravel-backpack.readme.io/docs/crud#revisions
         // $this->crud->allowAccess('revisions');
 
-        // ------ AJAX TABLE VIEW
-        // Please note the drawbacks of this though:
-        // - 1-n and n-n columns are not searchable
-        // - date and datetime columns won't be sortable anymore
-        // $this->crud->enableAjaxTable();
-
         // ------ DATATABLE EXPORT BUTTONS
         // Show export to PDF, CSV, XLS and Print buttons on the table view.
-        // Does not work well with AJAX datatables.
         // $this->crud->enableExportButtons();
 
         // ------ ADVANCED QUERIES


### PR DESCRIPTION
Since we now use AJAX tables by default there is no need to have the `$this->crud->enableAjaxTable()` within the stub. Caused some confusion on gitter.