### PR TITLE
Support for Backpack 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "backpack/crud": "4.0.*"
+        "backpack/crud": "4.1.*|^4.0.99"
     },
     "require-dev": {
         "phpunit/phpunit" : "^9.0||^7.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "backpack/crud": "4.1.*|^4.0.50"
+        "backpack/crud": "4.1.*"
     },
     "require-dev": {
         "phpunit/phpunit" : "^9.0||^7.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "backpack/crud": "4.1.*|^4.0.99"
+        "backpack/crud": "4.1.*|^4.0.50"
     },
     "require-dev": {
         "phpunit/phpunit" : "^9.0||^7.0",

--- a/src/Console/Commands/ChartBackpackCommand.php
+++ b/src/Console/Commands/ChartBackpackCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Backpack\Generators\Console\Commands;
+
+use Artisan;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class ChartBackpackCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backpack:chart {name}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a ChartController and route';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $studlyName = Str::studly($this->argument('name')); // aka Pascal Case
+        $kebabName = Str::kebab($this->argument('name'));
+
+        // Create the ChartController and show output
+        Artisan::call('backpack:chart-controller', ['name' => $studlyName]);
+        echo Artisan::output();
+
+        // Create the chart route
+        Artisan::call('backpack:add-custom-route', [
+            'code' => "Route::get('charts/".$kebabName."', 'Charts\\".$studlyName."ChartController@response');",
+        ]);
+        echo Artisan::output();
+    }
+}

--- a/src/Console/Commands/ChartBackpackCommand.php
+++ b/src/Console/Commands/ChartBackpackCommand.php
@@ -38,7 +38,7 @@ class ChartBackpackCommand extends Command
 
         // Create the chart route
         Artisan::call('backpack:add-custom-route', [
-            'code' => "Route::get('charts/".$kebabName."', 'Charts\\".$studlyName."ChartController@response');",
+            'code' => "Route::get('charts/".$kebabName."', 'Charts\\".$studlyName."ChartController@response')->name('charts.'.$kebabName.'.index');",
         ]);
         echo Artisan::output();
     }

--- a/src/Console/Commands/ChartControllerBackpackCommand.php
+++ b/src/Console/Commands/ChartControllerBackpackCommand.php
@@ -2,7 +2,6 @@
 
 namespace Backpack\Generators\Console\Commands;
 
-use Artisan;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
 

--- a/src/Console/Commands/ChartControllerBackpackCommand.php
+++ b/src/Console/Commands/ChartControllerBackpackCommand.php
@@ -2,31 +2,32 @@
 
 namespace Backpack\Generators\Console\Commands;
 
+use Artisan;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
 
-class CrudControllerBackpackCommand extends GeneratorCommand
+class ChartControllerBackpackCommand extends GeneratorCommand
 {
     /**
      * The console command name.
      *
      * @var string
      */
-    protected $name = 'backpack:crud-controller';
+    protected $name = 'backpack:chart-controller';
 
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'backpack:crud-controller {name}';
+    protected $signature = 'backpack:chart-controller {name}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Generate a Backpack CRUD controller';
+    protected $description = 'Generate a Backpack ChartController';
 
     /**
      * The type of class being generated.
@@ -46,7 +47,7 @@ class CrudControllerBackpackCommand extends GeneratorCommand
     {
         $name = str_replace($this->laravel->getNamespace(), '', $name);
 
-        return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'CrudController.php';
+        return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'ChartController.php';
     }
 
     /**
@@ -56,7 +57,7 @@ class CrudControllerBackpackCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/../stubs/crud-controller.stub';
+        return __DIR__.'/../stubs/chart-controller.stub';
     }
 
     /**
@@ -68,7 +69,7 @@ class CrudControllerBackpackCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace.'\Http\Controllers\Admin';
+        return $rootNamespace.'\Http\Controllers\Admin\Charts';
     }
 
     /**
@@ -79,12 +80,9 @@ class CrudControllerBackpackCommand extends GeneratorCommand
      *
      * @return string
      */
-    protected function replaceNameStrings(&$stub, $name)
+    protected function replaceRouteStrings(&$stub)
     {
-        $table = Str::plural(ltrim(strtolower(preg_replace('/[A-Z]/', '_$0', str_replace($this->getNamespace($name).'\\', '', $name))), '_'));
-
-        $stub = str_replace('DummyTable', $table, $stub);
-        $stub = str_replace('dummy_class', strtolower(str_replace($this->getNamespace($name).'\\', '', $name)), $stub);
+        $stub = str_replace('dummy-class', Str::kebab($this->argument('name')), $stub);
 
         return $this;
     }
@@ -100,7 +98,9 @@ class CrudControllerBackpackCommand extends GeneratorCommand
     {
         $stub = $this->files->get($this->getStub());
 
-        return $this->replaceNamespace($stub, $name)->replaceNameStrings($stub, $name)->replaceClass($stub, $name);
+        return $this->replaceNamespace($stub, $name)
+                    ->replaceRouteStrings($stub)
+                    ->replaceClass($stub, $name);
     }
 
     /**

--- a/src/Console/Commands/CrudBackpackCommand.php
+++ b/src/Console/Commands/CrudBackpackCommand.php
@@ -52,7 +52,7 @@ class CrudBackpackCommand extends Command
 
         // Create the sidebar item
         Artisan::call('backpack:add-sidebar-content', [
-            'code' => "<li class='nav-item'><a class='nav-link' href='{{ backpack_url('".$lowerName."') }}'><i class='nav-icon fa fa-question'></i> ".Str::plural($name).'</a></li>',
+            'code' => "<li class='nav-item'><a class='nav-link' href='{{ backpack_url('".$lowerName."') }}'><i class='nav-icon la la-question'></i> ".Str::plural($name).'</a></li>',
         ]);
         echo Artisan::output();
     }

--- a/src/Console/Commands/CrudOperationBackpackCommand.php
+++ b/src/Console/Commands/CrudOperationBackpackCommand.php
@@ -3,6 +3,7 @@
 namespace Backpack\Generators\Console\Commands;
 
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
 
 class CrudOperationBackpackCommand extends GeneratorCommand
 {
@@ -80,7 +81,7 @@ class CrudOperationBackpackCommand extends GeneratorCommand
      */
     protected function replaceNameStrings(&$stub, $name)
     {
-        $table = str_plural(ltrim(strtolower(preg_replace('/[A-Z]/', '_$0', str_replace($this->getNamespace($name).'\\', '', $name))), '_'));
+        $table = Str::plural(ltrim(strtolower(preg_replace('/[A-Z]/', '_$0', str_replace($this->getNamespace($name).'\\', '', $name))), '_'));
 
         $stub = str_replace('DummyTable', $table, $stub);
         $stub = str_replace('dummy_class', strtolower(str_replace($this->getNamespace($name).'\\', '', $name)), $stub);

--- a/src/Console/stubs/chart-controller.stub
+++ b/src/Console/stubs/chart-controller.stub
@@ -1,0 +1,47 @@
+<?php
+
+namespace DummyNamespace;
+
+use Backpack\CRUD\app\Http\Controllers\ChartController;
+use ConsoleTVs\Charts\Classes\Chartjs\Chart;
+
+/**
+ * Class DummyClassChartController
+ * @package App\Http\Controllers\Admin\Charts
+ * @property-read \Backpack\CRUD\app\Library\CrudPanel\CrudPanel $crud
+ */
+class DummyClassChartController extends ChartController
+{
+    public function setup()
+    {
+        $this->chart = new Chart();
+
+        // MANDATORY. Set the labels for the dataset points
+        $this->chart->labels([
+            'Today',
+        ]);
+
+        // RECOMMENDED. Set URL that the ChartJS library should call, to get its data using AJAX.
+        $this->chart->load(backpack_url('charts/dummy-class'));
+
+        // OPTIONAL
+        // $this->chart->minimalist(false);
+        // $this->chart->displayLegend(true);
+    }
+
+    /**
+     * Respond to AJAX calls with all the chart data points.
+     *
+     * @return json
+     */
+    // public function data()
+    // {
+    //     $users_created_today = \App\User::whereDate('created_at', today())->count();
+
+    //     $this->chart->dataset('Users Created', 'bar', [
+    //                 $users_created_today,
+    //             ])
+    //         ->color('rgba(205, 32, 31, 1)')
+    //         ->backgroundColor('rgba(205, 32, 31, 0.4)');
+    // }
+}

--- a/src/GeneratorsServiceProvider.php
+++ b/src/GeneratorsServiceProvider.php
@@ -2,11 +2,11 @@
 
 namespace Backpack\Generators;
 
+use Backpack\Generators\Console\Commands\ChartBackpackCommand;
+use Backpack\Generators\Console\Commands\ChartControllerBackpackCommand;
 use Backpack\Generators\Console\Commands\ConfigBackpackCommand;
 use Backpack\Generators\Console\Commands\CrudBackpackCommand;
-use Backpack\Generators\Console\Commands\ChartBackpackCommand;
 use Backpack\Generators\Console\Commands\CrudControllerBackpackCommand;
-use Backpack\Generators\Console\Commands\ChartControllerBackpackCommand;
 use Backpack\Generators\Console\Commands\CrudModelBackpackCommand;
 use Backpack\Generators\Console\Commands\CrudOperationBackpackCommand;
 use Backpack\Generators\Console\Commands\CrudRequestBackpackCommand;

--- a/src/GeneratorsServiceProvider.php
+++ b/src/GeneratorsServiceProvider.php
@@ -4,7 +4,9 @@ namespace Backpack\Generators;
 
 use Backpack\Generators\Console\Commands\ConfigBackpackCommand;
 use Backpack\Generators\Console\Commands\CrudBackpackCommand;
+use Backpack\Generators\Console\Commands\ChartBackpackCommand;
 use Backpack\Generators\Console\Commands\CrudControllerBackpackCommand;
+use Backpack\Generators\Console\Commands\ChartControllerBackpackCommand;
 use Backpack\Generators\Console\Commands\CrudModelBackpackCommand;
 use Backpack\Generators\Console\Commands\CrudOperationBackpackCommand;
 use Backpack\Generators\Console\Commands\CrudRequestBackpackCommand;
@@ -19,9 +21,11 @@ class GeneratorsServiceProvider extends ServiceProvider
         ConfigBackpackCommand::class,
         CrudModelBackpackCommand::class,
         CrudControllerBackpackCommand::class,
+        ChartControllerBackpackCommand::class,
         CrudOperationBackpackCommand::class,
         CrudRequestBackpackCommand::class,
         CrudBackpackCommand::class,
+        ChartBackpackCommand::class,
         ModelBackpackCommand::class,
         RequestBackpackCommand::class,
         ViewBackpackCommand::class,


### PR DESCRIPTION
- Adds commands needed by https://github.com/Laravel-Backpack/CRUD/pull/2596:
    - ```php artisan backpack:chart InactiveUsers``` - generates chart controller and route
    - ```php artisan backpack:chart-controller InactiveUsers``` - generates just chart controller
- removes some more Laravel string helpers (leftovers)
- provides support for Backpack 4.1
