### PR TITLE
Support for Backpack 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "backpack/crud": "4.0.*"
+        "backpack/crud": "^4.0.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "^9.0||^7.0",


### PR DESCRIPTION
Adding support for Backpack 4.1

>   Problem 1
    - Installation request for backpack/generators ^2.0 -> satisfiable by backpack/generators[2.0.0, 2.0.1, 2.0.2, 2.0.3, 2.0.4, 2.0.5, 2.0.6, v2.0.7].
    - Can only install one of: backpack/crud[4.0.x-dev, 4.1.x-dev].
    - Can only install one of: backpack/crud[4.0.x-dev, 4.1.x-dev].
    - Can only install one of: backpack/crud[4.0.x-dev, 4.1.x-dev].
    - Conclusion: install backpack/crud 4.0.x-dev
    - Installation request for backpack/crud ^4.1. -> satisfiable by backpack/crud[4.1.x-dev].