### PR TITLE
use CruidTrait by default.

### DIFF
--- a/src/Console/stubs/model.stub
+++ b/src/Console/stubs/model.stub
@@ -3,9 +3,13 @@
 namespace DummyNamespace;
 
 use Illuminate\Database\Eloquent\Model;
+use Backpack\CRUD\app\Models\Traits\CrudTrait;
 
 class DummyClass extends Model
 {
+
+    use CrudTrait;
+    
     /*
     |--------------------------------------------------------------------------
     | GLOBAL VARIABLES


### PR DESCRIPTION
When generating a model designed specifically to be used on Backpack we should include the required `CrudTrait` by default.