### PR TITLE
Update ChartBackpackCommand.php

### DIFF
--- a/src/Console/Commands/ChartBackpackCommand.php
+++ b/src/Console/Commands/ChartBackpackCommand.php
@@ -38,7 +38,7 @@ class ChartBackpackCommand extends Command
 
         // Create the chart route
         Artisan::call('backpack:add-custom-route', [
-            'code' => "Route::get('charts/".$kebabName."', 'Charts\\".$studlyName."ChartController@response')->name('charts.'.$kebabName.'.index');",
+            'code' => "Route::get('charts/".$kebabName."', 'Charts\\".$studlyName."ChartController@response')->name('charts.".$kebabName.".index');",
         ]);
         echo Artisan::output();
     }


### PR DESCRIPTION
This was generating a malformed route.

E.g.:

`php artisan backpack:chart MonthlyUsers`

Then auto-generated route was: 

`Route::get('charts/monthly-users', 'Charts\MonthlyUsersChartController@response')->name('charts.'.monthly-users.'.index');`

The name was malformed.

Cheers all for 4.1!
