### PR TITLE
Generate crud controllers with explicit fields and columns, not setFromDb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All Notable changes to `Backpack Generators` will be documented in this file
 
 ------------
+IMPORTANT
+------------
+
+Starting with version 3, the changelog is kept inside the Releases tab in our this repo's Github page. Please check https://github.com/Laravel-Backpack/Generators/releases
+
+------------
 
 ## 2.0.7 - 2020-03-05
 

--- a/src/Console/Commands/CrudControllerBackpackCommand.php
+++ b/src/Console/Commands/CrudControllerBackpackCommand.php
@@ -90,22 +90,6 @@ class CrudControllerBackpackCommand extends GeneratorCommand
         return $this;
     }
 
-    protected function getFields($model)
-    {
-        $columns = [];
-        $model = new $model;
-
-        // if fillable was defined, use that as the columns
-        if (! count($model->getFillable())) {
-            $columns = $model->getFillable();
-        } else {
-            // otherwise, if guarded is used, just pick up the columns straight from the bd table
-            $columns = \Schema::getColumnListing($model->getTable());
-        }
-
-        return $column;
-    }
-
     protected function getAttributes($model)
     {
         $attributes = [];

--- a/src/Console/Commands/CrudControllerBackpackCommand.php
+++ b/src/Console/Commands/CrudControllerBackpackCommand.php
@@ -146,8 +146,8 @@ class CrudControllerBackpackCommand extends GeneratorCommand
         }
 
         // replace setFromDb with actual fields and columns
-        $stub = str_replace('$this->crud->setFromDb(); // fields', implode(PHP_EOL.'        ', $fields), $stub);
-        $stub = str_replace('$this->crud->setFromDb(); // columns', implode(PHP_EOL.'        ', $columns), $stub);
+        $stub = str_replace('CRUD::setFromDb(); // fields', implode(PHP_EOL.'        ', $fields), $stub);
+        $stub = str_replace('CRUD::setFromDb(); // columns', implode(PHP_EOL.'        ', $columns), $stub);
 
         return $this;
     }

--- a/src/Console/Commands/CrudControllerBackpackCommand.php
+++ b/src/Console/Commands/CrudControllerBackpackCommand.php
@@ -3,8 +3,8 @@
 namespace Backpack\Generators\Console\Commands;
 
 use Illuminate\Console\GeneratorCommand;
-use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 class CrudControllerBackpackCommand extends GeneratorCommand
 {
@@ -96,7 +96,7 @@ class CrudControllerBackpackCommand extends GeneratorCommand
         $model = new $model;
 
         // if fillable was defined, use that as the columns
-        if (!count($model->getFillable())) {
+        if (! count($model->getFillable())) {
             $columns = $model->getFillable();
         } else {
             // otherwise, if guarded is used, just pick up the columns straight from the bd table
@@ -106,14 +106,13 @@ class CrudControllerBackpackCommand extends GeneratorCommand
         return $column;
     }
 
-
     protected function getAttributes($model)
     {
         $attributes = [];
         $model = new $model;
 
         // if fillable was defined, use that as the attributes
-        if (!count($model->getFillable())) {
+        if (! count($model->getFillable())) {
             $attributes = $model->getFillable();
         } else {
             // otherwise, if guarded is used, just pick up the columns straight from the bd table
@@ -136,7 +135,7 @@ class CrudControllerBackpackCommand extends GeneratorCommand
         $class = str_replace($this->getNamespace($name).'\\', '', $name);
         $model = 'App\Models\\'.$class;
 
-        if (!class_exists($model)) {
+        if (! class_exists($model)) {
             return $this;
         }
 
@@ -144,7 +143,7 @@ class CrudControllerBackpackCommand extends GeneratorCommand
 
         // create an array with the needed code for defining fields
         $fields = Arr::where($attributes, function ($value, $key) {
-            return !in_array($value, ['id', 'created_at', 'updated_at', 'deleted_at']);
+            return ! in_array($value, ['id', 'created_at', 'updated_at', 'deleted_at']);
         });
         if (count($fields)) {
             foreach ($fields as $key => $field) {
@@ -154,7 +153,7 @@ class CrudControllerBackpackCommand extends GeneratorCommand
 
         // create an array with the needed code for defining columns
         $columns = Arr::where($attributes, function ($value, $key) {
-            return !in_array($value, ['id']);
+            return ! in_array($value, ['id']);
         });
         if (count($columns)) {
             foreach ($columns as $key => $column) {
@@ -174,7 +173,7 @@ class CrudControllerBackpackCommand extends GeneratorCommand
      *
      * @param  string  $stub
      * @param  string  $name
-     * 
+     *
      * @return string
      */
     protected function replaceModel(&$stub, $name)

--- a/src/Console/stubs/crud-controller.stub
+++ b/src/Console/stubs/crud-controller.stub
@@ -21,23 +21,21 @@ class DummyClassCrudController extends CrudController
 
     public function setup()
     {
-        $this->crud->setModel('App\Models\DummyClass');
+        $this->crud->setModel(\App\Models\DummyClass::class);
         $this->crud->setRoute(config('backpack.base.route_prefix') . '/dummy_class');
         $this->crud->setEntityNameStrings('dummy_class', 'DummyTable');
     }
 
     protected function setupListOperation()
     {
-        // TODO: remove setFromDb() and manually define Columns, maybe Filters
-        $this->crud->setFromDb();
+        $this->crud->setFromDb(); // columns
     }
 
     protected function setupCreateOperation()
     {
         $this->crud->setValidation(DummyClassRequest::class);
 
-        // TODO: remove setFromDb() and manually define Fields
-        $this->crud->setFromDb();
+        $this->crud->setFromDb(); // fields
     }
 
     protected function setupUpdateOperation()

--- a/src/Console/stubs/crud-controller.stub
+++ b/src/Console/stubs/crud-controller.stub
@@ -21,21 +21,21 @@ class DummyClassCrudController extends CrudController
 
     public function setup()
     {
-        $this->crud->setModel(\App\Models\DummyClass::class);
-        $this->crud->setRoute(config('backpack.base.route_prefix') . '/dummy_class');
-        $this->crud->setEntityNameStrings('dummy_class', 'DummyTable');
+        CRUD::setModel(\App\Models\DummyClass::class);
+        CRUD::setRoute(config('backpack.base.route_prefix') . '/dummy_class');
+        CRUD::setEntityNameStrings('dummy_class', 'DummyTable');
     }
 
     protected function setupListOperation()
     {
-        $this->crud->setFromDb(); // columns
+        CRUD::setFromDb(); // columns
     }
 
     protected function setupCreateOperation()
     {
-        $this->crud->setValidation(DummyClassRequest::class);
+        CRUD::setValidation(DummyClassRequest::class);
 
-        $this->crud->setFromDb(); // fields
+        CRUD::setFromDb(); // fields
     }
 
     protected function setupUpdateOperation()

--- a/src/Console/stubs/crud-controller.stub
+++ b/src/Console/stubs/crud-controller.stub
@@ -19,6 +19,11 @@ class DummyClassCrudController extends CrudController
     use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
     use \Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
 
+    /**
+     * Configure the CrudPanel object. Apply settings to all operations.
+     * 
+     * @return void
+     */
     public function setup()
     {
         CRUD::setModel(\App\Models\DummyClass::class);
@@ -26,18 +31,48 @@ class DummyClassCrudController extends CrudController
         CRUD::setEntityNameStrings('dummy_class', 'DummyTable');
     }
 
+    /**
+     * Define what happens when the List operation is loaded.
+     * 
+     * @see  https://backpackforlaravel.com/docs/crud-operation-list-entries
+     * @return void
+     */
     protected function setupListOperation()
     {
         CRUD::setFromDb(); // columns
+
+        /**
+         * Columns can be defined using the fluent syntax or array syntax:
+         * - CRUD::column('price')->type('number');
+         * - CRUD::addColumn(['name' => 'price', 'type' => 'number']); 
+         */
     }
 
+    /**
+     * Define what happens when the Create operation is loaded.
+     * 
+     * @see https://backpackforlaravel.com/docs/crud-operation-create
+     * @return void
+     */
     protected function setupCreateOperation()
     {
         CRUD::setValidation(DummyClassRequest::class);
 
         CRUD::setFromDb(); // fields
+
+        /**
+         * Fields can be defined using the fluent syntax or array syntax:
+         * - CRUD::field('price')->type('number');
+         * - CRUD::addField(['name' => 'price', 'type' => 'number'])); 
+         */
     }
 
+    /**
+     * Define what happens when the Update operation is loaded.
+     * 
+     * @see https://backpackforlaravel.com/docs/crud-operation-update
+     * @return void
+     */
     protected function setupUpdateOperation()
     {
         $this->setupCreateOperation();


### PR DESCRIPTION
This PR replaces the `setFromDb()` statements in the CrudController stub with actual columns or fields. When someone generates a CrudController, here's how what they're getting is different:

```diff
    protected function setupListOperation()
    {
-        $this->crud->setFromDb();
+        CRUD::column('category_id');
+        CRUD::column('title');
+        CRUD::column('slug');
+        CRUD::column('content');
+        CRUD::column('image');
+        CRUD::column('status');
+        CRUD::column('date');
+        CRUD::column('featured');
+        CRUD::column('deleted_at');
+        CRUD::column('created_at');
+        CRUD::column('updated_at');
    }

    protected function setupCreateOperation()
    {
        $this->crud->setValidation(ArticleRequest::class);

-        $this->crud->setFromDb();
+        CRUD::field('category_id');
+        CRUD::field('title');
+        CRUD::field('slug');
+        CRUD::field('content');
+        CRUD::field('image');
+        CRUD::field('status');
+        CRUD::field('date');
+        CRUD::field('featured');
    }
```

By having explicit fields and columns, it will be MUCH easier for the developers to do what they normally do:
- change the type of a field/column
- change the label of a field/column
- remove a field/column
- add a new field/column

In 99% of all use cases, I expect this to be better than the old `setFromDb()` thing we generated before. 

We use the new fluent syntax that came with 4.1, since that's the one that is easiest to use for this type of changes.