### PR TITLE
Adds backpack:build command to generate CRUDs for all models

### DIFF
--- a/src/Console/Commands/BuildBackpackCommand.php
+++ b/src/Console/Commands/BuildBackpackCommand.php
@@ -4,8 +4,8 @@ namespace Backpack\Generators\Console\Commands;
 
 use Artisan;
 use Illuminate\Console\Command;
-use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 class BuildBackpackCommand extends Command
 {
@@ -33,23 +33,21 @@ class BuildBackpackCommand extends Command
         // make a list of all models
         $models = $this->getModels(base_path().'/app');
 
-        if (!count($models)) {
+        if (! count($models)) {
             $this->info('No models found.');
 
             return false;
         }
 
-        foreach ($models as $key => $model)
-        {
+        foreach ($models as $key => $model) {
             $this->info('--- '.$model.' ---');
             // Create the CrudController & Request
             // Attach CrudTrait to Model
             // Add sidebar item
-            // Add routes 
+            // Add routes
             Artisan::call('backpack:crud', ['name' => $model]);
             echo Artisan::output();
         }
-
     }
 
     private function getModels($path)
@@ -58,18 +56,18 @@ class BuildBackpackCommand extends Command
         $results = scandir($path);
 
         foreach ($results as $result) {
-
-            if ($result === '.' or $result === '..') continue;
-            $filename = $path . '/' . $result;
+            if ($result === '.' or $result === '..') {
+                continue;
+            }
+            $filename = $path.'/'.$result;
 
             if (is_dir($filename)) {
                 $out = array_merge($out, $this->getModels($filename));
             } else {
                 $file_content = file_get_contents($filename);
                 if (Str::contains($file_content, 'Illuminate\Database\Eloquent\Model') &&
-                    Str::contains($file_content, 'extends Model')) 
-                {
-                    $out[] = Arr::last(explode("/", substr($filename, 0, -4)));
+                    Str::contains($file_content, 'extends Model')) {
+                    $out[] = Arr::last(explode('/', substr($filename, 0, -4)));
                 }
             }
         }

--- a/src/Console/Commands/BuildBackpackCommand.php
+++ b/src/Console/Commands/BuildBackpackCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Backpack\Generators\Console\Commands;
+
+use Artisan;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Illuminate\Support\Arr;
+
+class BuildBackpackCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backpack:build';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create CRUDs for all Models that don\'t already have one.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // make a list of all models
+        $models = $this->getModels(base_path().'/app');
+
+        if (!count($models)) {
+            $this->info('No models found.');
+
+            return false;
+        }
+
+        foreach ($models as $key => $model)
+        {
+            $this->info('--- '.$model.' ---');
+            // Create the CrudController & Request
+            // Attach CrudTrait to Model
+            // Add sidebar item
+            // Add routes 
+            Artisan::call('backpack:crud', ['name' => $model]);
+            echo Artisan::output();
+        }
+
+    }
+
+    private function getModels($path)
+    {
+        $out = [];
+        $results = scandir($path);
+
+        foreach ($results as $result) {
+
+            if ($result === '.' or $result === '..') continue;
+            $filename = $path . '/' . $result;
+
+            if (is_dir($filename)) {
+                $out = array_merge($out, $this->getModels($filename));
+            } else {
+                $file_content = file_get_contents($filename);
+                if (Str::contains($file_content, 'Illuminate\Database\Eloquent\Model') &&
+                    Str::contains($file_content, 'extends Model')) 
+                {
+                    $out[] = Arr::last(explode("/", substr($filename, 0, -4)));
+                }
+            }
+        }
+
+        return $out;
+    }
+}

--- a/src/GeneratorsServiceProvider.php
+++ b/src/GeneratorsServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\Generators;
 
+use Backpack\Generators\Console\Commands\BuildBackpackCommand;
 use Backpack\Generators\Console\Commands\ChartBackpackCommand;
 use Backpack\Generators\Console\Commands\ChartControllerBackpackCommand;
 use Backpack\Generators\Console\Commands\ConfigBackpackCommand;
@@ -18,6 +19,7 @@ use Illuminate\Support\ServiceProvider;
 class GeneratorsServiceProvider extends ServiceProvider
 {
     protected $commands = [
+        BuildBackpackCommand::class,
         ConfigBackpackCommand::class,
         CrudModelBackpackCommand::class,
         CrudControllerBackpackCommand::class,


### PR DESCRIPTION
Fixes #76

Adds a `php artisan backpack:build` command, that goes through the App folder and looks at all the models that exist, then calls `php artisan backpack:crud` on each one of them.

Not sure it's general enough - it might currently work only inside the `Models` folder, and only for models who _directly_ extend the Eloquent model. But... it works!!

I'm open to feedback and improvements.

---

Rephrased, what this PR does is that it allows a different way of building Laravel apps with admin panels. You can build your entire front-end, in the process of course you'd be creating models. Then at the end, when you're done with the front-end, you can just install Backpack and run the `build` command, and it will generate admin panels for all models.