### PR TITLE
fix #98 - adding CrudTrait to Model generates error on Windows OS

### DIFF
--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -62,7 +62,7 @@ class CrudModelBackpackCommand extends GeneratorCommand
              ! $this->option('force')) &&
              $this->alreadyExists($this->getNameInput())) {
             $file = $this->files->get($path);
-            $file_array = explode(PHP_EOL, $file);
+            $file_array = preg_split('/(\r\n)|\r|\n/', $file);
 
             // check if it already uses CrudTrait
             // if it does, do nothing


### PR DESCRIPTION
See #98 for details. But in short using PHP_EOL has inconsistent results on Windows, and this PR tries to fix that by using regex instead.