### PR TITLE
Proper validation for models on app or models namespace

### DIFF
--- a/src/Console/Commands/BuildBackpackCommand.php
+++ b/src/Console/Commands/BuildBackpackCommand.php
@@ -2,7 +2,6 @@
 
 namespace Backpack\Generators\Console\Commands;
 
-use Artisan;
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -34,19 +33,18 @@ class BuildBackpackCommand extends Command
         $models = $this->getModels(base_path().'/app');
 
         if (! count($models)) {
-            $this->info('No models found.');
+            $this->error('No models found.');
 
             return false;
         }
 
         foreach ($models as $key => $model) {
-            $this->info('--- '.$model.' ---');
+            $this->info("--- $model ---");
             // Create the CrudController & Request
             // Attach CrudTrait to Model
             // Add sidebar item
             // Add routes
-            Artisan::call('backpack:crud', ['name' => $model]);
-            echo Artisan::output();
+            $this->call('backpack:crud', ['name' => $model]);
         }
     }
 

--- a/src/Console/Commands/ChartBackpackCommand.php
+++ b/src/Console/Commands/ChartBackpackCommand.php
@@ -2,7 +2,6 @@
 
 namespace Backpack\Generators\Console\Commands;
 
-use Artisan;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 
@@ -33,13 +32,11 @@ class ChartBackpackCommand extends Command
         $kebabName = Str::kebab($this->argument('name'));
 
         // Create the ChartController and show output
-        Artisan::call('backpack:chart-controller', ['name' => $studlyName]);
-        echo Artisan::output();
+        $this->call('backpack:chart-controller', ['name' => $studlyName]);
 
         // Create the chart route
-        Artisan::call('backpack:add-custom-route', [
-            'code' => "Route::get('charts/".$kebabName."', 'Charts\\".$studlyName."ChartController@response')->name('charts.$kebabName.index');",
+        $this->call('backpack:add-custom-route', [
+            'code' => "Route::get('charts/{$kebabName}', 'Charts\\{$studlyName}ChartController@response')->name('charts.{$kebabName}.index');",
         ]);
-        echo Artisan::output();
     }
 }

--- a/src/Console/Commands/ConfigBackpackCommand.php
+++ b/src/Console/Commands/ConfigBackpackCommand.php
@@ -67,7 +67,7 @@ class ConfigBackpackCommand extends GeneratorCommand
         $path = $this->getPath($name);
 
         if ($this->alreadyExists($this->getNameInput())) {
-            $this->error($this->type.' already exists!');
+            $this->error($this->type.' already existed!');
 
             return false;
         }

--- a/src/Console/Commands/CrudBackpackCommand.php
+++ b/src/Console/Commands/CrudBackpackCommand.php
@@ -2,7 +2,6 @@
 
 namespace Backpack\Generators\Console\Commands;
 
-use Artisan;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 
@@ -31,29 +30,25 @@ class CrudBackpackCommand extends Command
     {
         $name = ucfirst($this->argument('name'));
         $lowerName = strtolower($this->argument('name'));
+        $pluralName = Str::plural($name);
 
         // Create the CRUD Controller and show output
-        Artisan::call('backpack:crud-controller', ['name' => $name]);
-        echo Artisan::output();
+        $this->call('backpack:crud-controller', ['name' => $name]);
 
         // Create the CRUD Model and show output
-        Artisan::call('backpack:crud-model', ['name' => $name]);
-        echo Artisan::output();
+        $this->call('backpack:crud-model', ['name' => $name]);
 
         // Create the CRUD Request and show output
-        Artisan::call('backpack:crud-request', ['name' => $name]);
-        echo Artisan::output();
+        $this->call('backpack:crud-request', ['name' => $name]);
 
         // Create the CRUD route
-        Artisan::call('backpack:add-custom-route', [
-            'code' => "Route::crud('".$lowerName."', '".$name."CrudController');",
+        $this->call('backpack:add-custom-route', [
+            'code' => "Route::crud('$lowerName', '{$name}CrudController');",
         ]);
-        echo Artisan::output();
 
         // Create the sidebar item
-        Artisan::call('backpack:add-sidebar-content', [
-            'code' => "<li class='nav-item'><a class='nav-link' href='{{ backpack_url('".$lowerName."') }}'><i class='nav-icon la la-question'></i> ".Str::plural($name).'</a></li>',
+        $this->call('backpack:add-sidebar-content', [
+            'code' => "<li class='nav-item'><a class='nav-link' href='{{ backpack_url('$lowerName') }}'><i class='nav-icon la la-question'></i> $pluralName</a></li>",
         ]);
-        echo Artisan::output();
     }
 }

--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -51,37 +51,61 @@ class CrudModelBackpackCommand extends GeneratorCommand
      */
     public function handle()
     {
-        $name = $this->qualifyClass($this->getNameInput());
+        $name = $this->getNameInput();
+        $namespaceApp = $this->qualifyClass($this->getNameInput());
+        $namespaceModels = $this->qualifyClass('/Models/' . $this->getNameInput());
 
+        // Check if exists on app or models
+        $existsOnApp = $this->alreadyExists($namespaceApp);
+        $existsOnModels = $this->alreadyExists($namespaceModels);
+
+        // If no model was found, we will generate the path to the location where this class file
+        // should be written. Then, we will build the class and make the proper replacements on
+        // the stub files so that it gets the correctly formatted namespace and class name.
+        if (!$existsOnApp && !$existsOnModels) {
+            $this->makeDirectory($namespaceModels);
+
+            $this->files->put($this->getPath($namespaceModels), $this->sortImports($this->buildClass($namespaceModels)));
+
+            $this->info($this->type . ' created successfully.');
+            return;
+        }
+
+        // If it was found on both namespaces, we'll ask user to pick one of them
+        if ($existsOnApp && $existsOnModels) {
+            $result = $this->choice('Multiple models with this name were found, which one do you want to use?', [
+                1 => "Use $namespaceApp",
+                2 => "Use $namespaceModels",
+            ]);
+
+            // Disable the namespace not selected
+            $existsOnApp = $result === 1;
+            $existsOnModels = $result === 2;
+        }
+
+        $name = $existsOnApp ? $namespaceApp : $namespaceModels;
         $path = $this->getPath($name);
 
-        // First we will check to see if the class already exists. If it does, we don't want
-        // to create the class and overwrite the user's code. We just make sure it uses CrudTrait
-        // We add that one line. Otherwise, we will continue generating this class' files.
-        if ((! $this->hasOption('force') ||
-             ! $this->option('force')) &&
-             $this->alreadyExists($this->getNameInput())) {
+        // As the class already exists, we don't want to create the class and overwrite the
+        // user's code. We just make sure it uses CrudTrait. We add that one line.
+        if (!$this->hasOption('force') || !$this->option('force')) {
             $file = $this->files->get($path);
-            $file_array = preg_split('/(\r\n)|\r|\n/', $file);
+            $lines = preg_split('/(\r\n)|\r|\n/', $file);
 
             // check if it already uses CrudTrait
             // if it does, do nothing
-            if (Str::contains($file, [$this->crudTrait])) {
-                $this->info('Model already exists and uses CrudTrait.');
-
-                return false;
+            if (Str::contains($file, $this->crudTrait)) {
+                $this->error('Model already uses CrudTrait.');
+                return;
             }
 
             // if it does not have CrudTrait, add the trait on the Model
-
-            $classDefinition = 'class '.$this->getNameInput().' extends';
-
-            foreach ($file_array as $key => $line) {
-                if (Str::contains($line, $classDefinition)) {
+            foreach ($lines as $key => $line) {
+                if (Str::contains($line, "class {$this->getNameInput()} extends")) {
                     if (Str::endsWith($line, '{')) {
                         // add the trait on the next
                         $position = $key + 1;
-                    } elseif ($file_array[$key + 1] == '{') {
+                    } elseif ($lines[$key + 1] == '{') {
                         // add the trait on the next next line
                         $position = $key + 2;
                     }
@@ -91,31 +115,21 @@ class CrudModelBackpackCommand extends GeneratorCommand
                     // IDEs start counting from 1
 
                     // add CrudTrait
-                    array_splice($file_array, $position, 0, '    use \\'.$this->crudTrait.';');
+                    array_splice($lines, $position, 0, "    use \\{$this->crudTrait};");
 
                     // save the file
-                    $this->files->put($path, implode(PHP_EOL, $file_array));
+                    $this->files->put($path, implode(PHP_EOL, $lines));
 
                     // let the user know what we've done
-                    $this->info('Model already exists! We just added CrudTrait on it.');
-
-                    return false;
+                    $this->error('Model already exists!');
+                    $this->info('We\'ve added CrudTrait on the Model.');
+                    return;
                 }
             }
 
-            $this->error('Model already exists! Could not add CrudTrait - please add manually.');
-
-            return false;
+            // In case we couldn't add the CrudTrait
+            $this->error("Model already exists on '$name' and we couldn't add CrudTrait. Please add it manually.");
         }
-
-        // Next, we will generate the path to the location where this class' file should get
-        // written. Then, we will build the class and make the proper replacements on the
-        // stub files so that it gets the correctly formatted namespace and class name.
-        $this->makeDirectory($path);
-
-        $this->files->put($path, $this->sortImports($this->buildClass($name)));
-
-        $this->info($this->type.' created successfully.');
     }
 
     /**
@@ -126,18 +140,6 @@ class CrudModelBackpackCommand extends GeneratorCommand
     protected function getStub()
     {
         return __DIR__.'/../stubs/crud-model.stub';
-    }
-
-    /**
-     * Get the default namespace for the class.
-     *
-     * @param string $rootNamespace
-     *
-     * @return string
-     */
-    protected function getDefaultNamespace($rootNamespace)
-    {
-        return $rootNamespace.'\Models';
     }
 
     /**

--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -53,7 +53,7 @@ class CrudModelBackpackCommand extends GeneratorCommand
     {
         $name = $this->getNameInput();
         $namespaceApp = $this->qualifyClass($this->getNameInput());
-        $namespaceModels = $this->qualifyClass('/Models/' . $this->getNameInput());
+        $namespaceModels = $this->qualifyClass('/Models/'.$this->getNameInput());
 
         // Check if exists on app or models
         $existsOnApp = $this->alreadyExists($namespaceApp);
@@ -62,12 +62,13 @@ class CrudModelBackpackCommand extends GeneratorCommand
         // If no model was found, we will generate the path to the location where this class file
         // should be written. Then, we will build the class and make the proper replacements on
         // the stub files so that it gets the correctly formatted namespace and class name.
-        if (!$existsOnApp && !$existsOnModels) {
+        if (! $existsOnApp && ! $existsOnModels) {
             $this->makeDirectory($namespaceModels);
 
             $this->files->put($this->getPath($namespaceModels), $this->sortImports($this->buildClass($namespaceModels)));
 
-            $this->info($this->type . ' created successfully.');
+            $this->info($this->type.' created successfully.');
+
             return;
         }
 
@@ -88,7 +89,7 @@ class CrudModelBackpackCommand extends GeneratorCommand
 
         // As the class already exists, we don't want to create the class and overwrite the
         // user's code. We just make sure it uses CrudTrait. We add that one line.
-        if (!$this->hasOption('force') || !$this->option('force')) {
+        if (! $this->hasOption('force') || ! $this->option('force')) {
             $file = $this->files->get($path);
             $lines = preg_split('/(\r\n)|\r|\n/', $file);
 
@@ -96,6 +97,7 @@ class CrudModelBackpackCommand extends GeneratorCommand
             // if it does, do nothing
             if (Str::contains($file, $this->crudTrait)) {
                 $this->error('Model already uses CrudTrait.');
+
                 return;
             }
 
@@ -123,6 +125,7 @@ class CrudModelBackpackCommand extends GeneratorCommand
                     // let the user know what we've done
                     $this->error('Model already exists!');
                     $this->info('We\'ve added CrudTrait on the Model.');
+
                     return;
                 }
             }

--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -96,7 +96,7 @@ class CrudModelBackpackCommand extends GeneratorCommand
             // check if it already uses CrudTrait
             // if it does, do nothing
             if (Str::contains($file, $this->crudTrait)) {
-                $this->error('Model already uses CrudTrait.');
+                $this->info('Model already used CrudTrait.');
 
                 return;
             }

--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -130,7 +130,7 @@ class CrudModelBackpackCommand extends GeneratorCommand
             }
 
             // In case we couldn't add the CrudTrait
-            $this->error("Model already exists on '$name' and we couldn't add CrudTrait. Please add it manually.");
+            $this->error("Model already existed on '$name' and we couldn't add CrudTrait. Please add it manually.");
         }
     }
 

--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -123,8 +123,7 @@ class CrudModelBackpackCommand extends GeneratorCommand
                     $this->files->put($path, implode(PHP_EOL, $lines));
 
                     // let the user know what we've done
-                    $this->error('Model already exists!');
-                    $this->info('We\'ve added CrudTrait on the Model.');
+                    $this->info('Model already existed. Added CrudTrait to it.');
 
                     return;
                 }

--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -96,7 +96,7 @@ class CrudModelBackpackCommand extends GeneratorCommand
             // check if it already uses CrudTrait
             // if it does, do nothing
             if (Str::contains($file, $this->crudTrait)) {
-                $this->info('Model already used CrudTrait.');
+                $this->comment('Model already used CrudTrait.');
 
                 return;
             }

--- a/src/Console/Commands/ViewBackpackCommand.php
+++ b/src/Console/Commands/ViewBackpackCommand.php
@@ -71,7 +71,7 @@ class ViewBackpackCommand extends GeneratorCommand
         $path = $this->getPath($name);
 
         if ($this->alreadyExists($this->getNameInput())) {
-            $this->error($this->type.' already exists!');
+            $this->error($this->type.' already existed!');
 
             return false;
         }


### PR DESCRIPTION
Fix for #97.

This PR validates Models on `\App\` namespace and `\App\Models\` namespace.
If both exists user is prompt to select wish one to use.

I had to move all `Artisan::call()` to `$this->call()` to be able to use prompts.

```
Controller already exists!

Multiple models with this name were found, which one do you want to use?:
  [1] Use App\Test
  [2] Use App\Models\Test
 > 1
1

Model already uses CrudTrait.
Request already exists!
Route already exists!
Sidebar item already exists!
```

Also, by using `$this->call()` messages are properly highlighted.
![image](https://user-images.githubusercontent.com/1838187/104067059-5f735580-51fa-11eb-89ab-4fd94792c6c5.png)
![image](https://user-images.githubusercontent.com/1838187/104067078-669a6380-51fa-11eb-855b-9e089b5be43b.png)
