### PR TITLE
Fixed wrong condition causing fields and columns to not be filled

### DIFF
--- a/src/Console/Commands/CrudControllerBackpackCommand.php
+++ b/src/Console/Commands/CrudControllerBackpackCommand.php
@@ -96,7 +96,7 @@ class CrudControllerBackpackCommand extends GeneratorCommand
         $model = new $model;
 
         // if fillable was defined, use that as the attributes
-        if (! count($model->getFillable())) {
+        if (count($model->getFillable())) {
             $attributes = $model->getFillable();
         } else {
             // otherwise, if guarded is used, just pick up the columns straight from the bd table
@@ -116,8 +116,8 @@ class CrudControllerBackpackCommand extends GeneratorCommand
      */
     protected function replaceSetFromDb(&$stub, $name)
     {
-        $class = str_replace($this->getNamespace($name).'\\', '', $name);
-        $model = 'App\Models\\'.$class;
+        $class = Str::afterLast($name, '\\');
+        $model = "App\\Models\\$class";
 
         if (! class_exists($model)) {
             return $this;
@@ -126,24 +126,20 @@ class CrudControllerBackpackCommand extends GeneratorCommand
         $attributes = $this->getAttributes($model);
 
         // create an array with the needed code for defining fields
-        $fields = Arr::where($attributes, function ($value, $key) {
-            return ! in_array($value, ['id', 'created_at', 'updated_at', 'deleted_at']);
-        });
-        if (count($fields)) {
-            foreach ($fields as $key => $field) {
-                $fields[$key] = "CRUD::field('".$field."');";
-            }
-        }
+        $fields = Arr::except($attributes, ['id', 'created_at', 'updated_at', 'deleted_at']);
+        $fields = collect($fields)
+            ->map(function ($field) {
+                return "CRUD::column('$field');";
+            })
+            ->toArray();
 
         // create an array with the needed code for defining columns
-        $columns = Arr::where($attributes, function ($value, $key) {
-            return ! in_array($value, ['id']);
-        });
-        if (count($columns)) {
-            foreach ($columns as $key => $column) {
-                $columns[$key] = "CRUD::column('".$column."');";
-            }
-        }
+        $columns = Arr::except($attributes, ['id']);
+        $columns = collect($columns)
+            ->map(function ($column) {
+                return "CRUD::column('$column');";
+            })
+            ->toArray();
 
         // replace setFromDb with actual fields and columns
         $stub = str_replace('CRUD::setFromDb(); // fields', implode(PHP_EOL.'        ', $fields), $stub);


### PR DESCRIPTION
This PR fixes the problem reported here; https://github.com/Laravel-Backpack/Generators/issues/95#issuecomment-665967884 and confirmed by @tabacitu here; https://github.com/Laravel-Backpack/Generators/issues/95#issuecomment-760959721

The problem was;
```php
if (! count($model->getFillable())) {
    $attributes = $model->getFillable();
```

That is inverted, so, if there is fillable, we use it.
Refactored `replaceSetFromDb` a little bit along the way.