### PR TITLE
clear route cache when adding routes

### DIFF
--- a/src/Console/Commands/CrudBackpackCommand.php
+++ b/src/Console/Commands/CrudBackpackCommand.php
@@ -53,7 +53,7 @@ class CrudBackpackCommand extends Command
 
         // if the application uses cached routes, we should rebuild the cache so the previous added route will
         // be acessible without manually clearing the route cache.
-        if(app()->routesAreCached()) {
+        if (app()->routesAreCached()) {
             $this->call('route:cache');
         }
     }


### PR DESCRIPTION
if the app uses cached routes, we should rebuild the route cache otherwise dev. must do it manually after creating the route and adding the sidebar item. 

