### PR TITLE
Fix for multiple word crud command

### DIFF
--- a/src/Console/Commands/CrudBackpackCommand.php
+++ b/src/Console/Commands/CrudBackpackCommand.php
@@ -28,27 +28,28 @@ class CrudBackpackCommand extends Command
      */
     public function handle()
     {
-        $name = ucfirst($this->argument('name'));
-        $lowerName = strtolower($this->argument('name'));
-        $pluralName = Str::plural($name);
+        $name = Str::of($this->argument('name'));
+        $nameTitle = $name->camel()->ucfirst();
+        $nameKebab = $nameTitle->kebab();
+        $namePlural = $nameKebab->plural()->replace('-', ' ')->title();
 
         // Create the CRUD Controller and show output
-        $this->call('backpack:crud-controller', ['name' => $name]);
+        $this->call('backpack:crud-controller', ['name' => $nameTitle]);
 
         // Create the CRUD Model and show output
-        $this->call('backpack:crud-model', ['name' => $name]);
+        $this->call('backpack:crud-model', ['name' => $nameTitle]);
 
         // Create the CRUD Request and show output
-        $this->call('backpack:crud-request', ['name' => $name]);
+        $this->call('backpack:crud-request', ['name' => $nameTitle]);
 
         // Create the CRUD route
         $this->call('backpack:add-custom-route', [
-            'code' => "Route::crud('$lowerName', '{$name}CrudController');",
+            'code' => "Route::crud('$nameKebab', '{$nameTitle}CrudController');",
         ]);
 
         // Create the sidebar item
         $this->call('backpack:add-sidebar-content', [
-            'code' => "<li class='nav-item'><a class='nav-link' href='{{ backpack_url('$lowerName') }}'><i class='nav-icon la la-question'></i> $pluralName</a></li>",
+            'code' => "<li class='nav-item'><a class='nav-link' href='{{ backpack_url('$nameKebab') }}'><i class='nav-icon la la-question'></i> $namePlural</a></li>",
         ]);
 
         // if the application uses cached routes, we should rebuild the cache so the previous added route will

--- a/src/Console/Commands/CrudControllerBackpackCommand.php
+++ b/src/Console/Commands/CrudControllerBackpackCommand.php
@@ -82,10 +82,15 @@ class CrudControllerBackpackCommand extends GeneratorCommand
      */
     protected function replaceNameStrings(&$stub, $name)
     {
-        $table = Str::plural(ltrim(strtolower(preg_replace('/[A-Z]/', '_$0', str_replace($this->getNamespace($name).'\\', '', $name))), '_'));
+        $nameTitle = Str::of($name)->afterLast('\\');
+        $nameKebab = $nameTitle->kebab();
+        $nameSingular = $nameKebab->replace('-', ' ')->title();
+        $namePlural = $nameSingular->plural();
 
-        $stub = str_replace('DummyTable', $table, $stub);
-        $stub = str_replace('dummy_class', strtolower(str_replace($this->getNamespace($name).'\\', '', $name)), $stub);
+        $stub = str_replace('DummyClass', $nameTitle, $stub);
+        $stub = str_replace('dummy-class', $nameKebab, $stub);
+        $stub = str_replace('dummy singular', $nameSingular, $stub);
+        $stub = str_replace('dummy plural', $namePlural, $stub);
 
         return $this;
     }

--- a/src/Console/Commands/CrudControllerBackpackCommand.php
+++ b/src/Console/Commands/CrudControllerBackpackCommand.php
@@ -84,7 +84,7 @@ class CrudControllerBackpackCommand extends GeneratorCommand
     {
         $nameTitle = Str::of($name)->afterLast('\\');
         $nameKebab = $nameTitle->kebab();
-        $nameSingular = $nameKebab->replace('-', ' ')->title();
+        $nameSingular = $nameKebab->replace('-', ' ');
         $namePlural = $nameSingular->plural();
 
         $stub = str_replace('DummyClass', $nameTitle, $stub);

--- a/src/Console/stubs/crud-controller.stub
+++ b/src/Console/stubs/crud-controller.stub
@@ -27,8 +27,8 @@ class DummyClassCrudController extends CrudController
     public function setup()
     {
         CRUD::setModel(\App\Models\DummyClass::class);
-        CRUD::setRoute(config('backpack.base.route_prefix') . '/dummy_class');
-        CRUD::setEntityNameStrings('dummy_class', 'DummyTable');
+        CRUD::setRoute(config('backpack.base.route_prefix') . '/dummy-class');
+        CRUD::setEntityNameStrings('dummy singular', 'dummy plural');
     }
 
     /**


### PR DESCRIPTION
Until now doing something like;

`php artisan backpack:crud ...`
`product_category` renders `Route::crud('product_category', 'Product_categoryCrudController');`
`product-category` renders `Route::crud('product-category', 'Product-categoryCrudController');`
`productCategory` renders `Route::crud('productcategory', 'ProductCategoryCrudController');`

Also, the controller entity names were wrong.
```CRUD::setEntityNameStrings('productcategory', 'product_categories');```

--- 

This PR allows devs to use any format, either kebab-case, snake_case or Title Case.

`php artisan backpack:crud ...`
`product_category`, `product-category`, `productCategory`

It will always render what is expected.



`routes/custom.php`
```php
Route::crud('product-category', 'ProductCategoryCrudController');
```
`sidebar_content.blade.php`
```html
<li class='nav-item'><a class='nav-link' href='{{ backpack_url('product-category') }}'>
    <i class='nav-icon la la-question'></i> Product Categories</a>
</li>
```
`ProductCategoryCrudController.php`
```php
public function setup()
{
    CRUD::setModel(\App\Models\ProductCategory::class);
    CRUD::setRoute(config('backpack.base.route_prefix') . '/product-category');
    CRUD::setEntityNameStrings('Product Category', 'Product Categories');
}
```