### PR TITLE
Re-Sort Create functions

### DIFF
--- a/src/Console/Commands/CrudBackpackCommand.php
+++ b/src/Console/Commands/CrudBackpackCommand.php
@@ -33,11 +33,12 @@ class CrudBackpackCommand extends Command
         $nameKebab = Str::kebab($nameTitle);
         $namePlural = ucfirst(str_replace('-', ' ', Str::plural($nameKebab)));
 
-        // Create the CRUD Controller and show output
-        $this->call('backpack:crud-controller', ['name' => $nameTitle]);
 
         // Create the CRUD Model and show output
         $this->call('backpack:crud-model', ['name' => $nameTitle]);
+
+        // Create the CRUD Controller and show output
+        $this->call('backpack:crud-controller', ['name' => $nameTitle]);
 
         // Create the CRUD Request and show output
         $this->call('backpack:crud-request', ['name' => $nameTitle]);


### PR DESCRIPTION
### issue 
creating controller before model

### fix
I believe in Laravel the standard order is: 
1. migrations 
2. models 
3. controllers
4. crud-request
5. routes