### PR TITLE
Lingual stubs and label field by default 

### DIFF
--- a/src/Console/Commands/CrudControllerBackpackCommand.php
+++ b/src/Console/Commands/CrudControllerBackpackCommand.php
@@ -134,7 +134,8 @@ class CrudControllerBackpackCommand extends GeneratorCommand
         $fields = Arr::except($attributes, ['id', 'created_at', 'updated_at', 'deleted_at']);
         $fields = collect($fields)
             ->map(function ($field) {
-                return "CRUD::field('$field');";
+                $label = Str::of($field)->replace('_',' ')->title();
+                return "CRUD::field('$field')->label(__('$label'));";
             })
             ->toArray();
 
@@ -142,7 +143,8 @@ class CrudControllerBackpackCommand extends GeneratorCommand
         $columns = Arr::except($attributes, ['id']);
         $columns = collect($columns)
             ->map(function ($column) {
-                return "CRUD::column('$column');";
+                $label = Str::of($field)->replace('_',' ')->title();
+                return "CRUD::column('$column')->label(__('$label'));";
             })
             ->toArray();
 

--- a/src/Console/stubs/crud-controller.stub
+++ b/src/Console/stubs/crud-controller.stub
@@ -28,7 +28,7 @@ class DummyClassCrudController extends CrudController
     {
         CRUD::setModel(\App\Models\DummyClass::class);
         CRUD::setRoute(config('backpack.base.route_prefix') . '/dummy-class');
-        CRUD::setEntityNameStrings('dummy singular', 'dummy plural');
+        CRUD::setEntityNameStrings(__('dummy singular'), __('dummy plural'));
     }
 
     /**


### PR DESCRIPTION
A small change in stub to allow multilingual if used and label field for each field by default