### PR TITLE
use escaped double-slash to avoid inner single slash

### DIFF
--- a/src/Console/Commands/CrudBackpackCommand.php
+++ b/src/Console/Commands/CrudBackpackCommand.php
@@ -49,7 +49,7 @@ class CrudBackpackCommand extends Command
 
         // Create the sidebar item
         $this->call('backpack:add-sidebar-content', [
-            'code' => "<li class='nav-item'><a class='nav-link' href='{{ backpack_url('$nameKebab') }}'><i class='nav-icon la la-question'></i> $namePlural</a></li>",
+            'code' => "<li class=\"nav-item\"><a class=\"nav-link\" href=\"{{ backpack_url('$nameKebab') }}\"><i class=\"nav-icon la la-question\"></i> $namePlural</a></li>",
         ]);
 
         // if the application uses cached routes, we should rebuild the cache so the previous added route will


### PR DESCRIPTION
fixes: #125

## WHY

### BEFORE - What was wrong? What was happening before this PR?
The generated sidebar item would be:
`<li class='nav-item'><a class='nav-link' href='{{ backpack_url('page') }}'><i class='nav-icon la la-question'></i> Pages</a></li>`

### AFTER - What is happening after this PR?

The generated sidebar item becomes:
`<li class="nav-item"><a class="nav-link" href="{{ backpack_url('page') }}"><i class="nav-icon la la-question"></i> Pages</a></li>`

## HOW

### How did you achieve that, in technical terms?

Use escaped double string instead of single quotes that would become nested when echoing the blade syntax.

### Is it a breaking change or non-breaking change?

I don't think it's a breaking one.


### How can we test the before & after?

??
