### PR TITLE
Fix location for where model is generated

### DIFF
--- a/src/Console/Commands/ModelBackpackCommand.php
+++ b/src/Console/Commands/ModelBackpackCommand.php
@@ -57,7 +57,7 @@ class ModelBackpackCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace;
+        return $rootNamespace.'\Test';
     }
 
     /**

--- a/src/Console/Commands/ModelBackpackCommand.php
+++ b/src/Console/Commands/ModelBackpackCommand.php
@@ -57,7 +57,7 @@ class ModelBackpackCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace.'\Test';
+        return $rootNamespace.'\Models';
     }
 
     /**


### PR DESCRIPTION
With new backpack versions using newer Laravel version and they have the different location should be adjusted to that. Perhaps could add in an option to use the old location but Backpack:Crud-Model puts it in the 'App\Models' folder.

## WHY

### BEFORE - What was wrong? What was happening before this PR?

Location for new models was simply `App` instead of the new `App\Models` location. `Backpack:Crud-Model` uses the correct location.

### AFTER - What is happening after this PR?

Corrected location for when models are generated.

## HOW

### How did you achieve that, in technical terms?

Simply adjusted the path for the namespace.

### Is it a breaking change or non-breaking change?

Depends on the version of Laravel being used anything older then 8 it may be.


### How can we test the before & after?

Adjust the namespace. 
