### PR TITLE
use the camelcased version of operation name

### DIFF
--- a/src/Console/Commands/CrudOperationBackpackCommand.php
+++ b/src/Console/Commands/CrudOperationBackpackCommand.php
@@ -78,10 +78,13 @@ class CrudOperationBackpackCommand extends GeneratorCommand
      */
     protected function replaceNameStrings(&$stub, $name)
     {
-        $table = Str::plural(ltrim(strtolower(preg_replace('/[A-Z]/', '_$0', str_replace($this->getNamespace($name).'\\', '', $name))), '_'));
+        $name = Str::of($name)->afterLast('\\');
 
-        $stub = str_replace('DummyTable', $table, $stub);
-        $stub = str_replace('dummy_class', strtolower(str_replace($this->getNamespace($name).'\\', '', $name)), $stub);
+        $stub = str_replace('DummyClass', $name->studly(), $stub);
+        $stub = str_replace('dummyClass', $name->lcfirst(), $stub);
+        $stub = str_replace('Dummy Class', $name->snake()->replace('_', ' ')->title(), $stub);
+        $stub = str_replace('dummy-class', $name->snake('-'), $stub);
+        $stub = str_replace('dummy_class', $name->snake(), $stub);
 
         return $this;
     }
@@ -96,7 +99,10 @@ class CrudOperationBackpackCommand extends GeneratorCommand
     {
         $stub = $this->files->get($this->getStub());
 
-        return $this->replaceNamespace($stub, $name)->replaceNameStrings($stub, $name)->replaceClass($stub, $name);
+        return $this
+            ->replaceNamespace($stub, $name)
+            ->replaceNameStrings($stub, $name)
+            ->replaceClass($stub, $name);
     }
 
     /**
@@ -109,5 +115,17 @@ class CrudOperationBackpackCommand extends GeneratorCommand
         return [
 
         ];
+    }
+
+    /**
+     * Get the desired class name from the input.
+     *
+     * @return string
+     */
+    protected function getNameInput()
+    {
+        return Str::of($this->argument('name'))
+            ->trim()
+            ->studly();
     }
 }

--- a/src/Console/stubs/crud-operation.stub
+++ b/src/Console/stubs/crud-operation.stub
@@ -18,7 +18,7 @@ trait DummyClassOperation
         Route::get($segment.'/dummy_class', [
             'as'        => $routeName.'.dummy_class',
             'uses'      => $controller.'@dummy_class',
-            'operation' => 'dummy_class',
+            'operation' => 'DummyClass',
         ]);
     }
 
@@ -27,9 +27,9 @@ trait DummyClassOperation
      */
     protected function setupDummyClassDefaults()
     {
-        $this->crud->allowAccess('dummy_class');
+        $this->crud->allowAccess('DummyClass');
 
-        $this->crud->operation('dummy_class', function () {
+        $this->crud->operation('DummyClass', function () {
             $this->crud->loadDefaultOperationSettingsFromConfig();
         });
 
@@ -46,7 +46,7 @@ trait DummyClassOperation
      */
     public function dummy_class()
     {
-        $this->crud->hasAccessOrFail('dummy_class');
+        $this->crud->hasAccessOrFail('DummyClass');
 
         // prepare the fields you need to show
         $this->data['crud'] = $this->crud;

--- a/src/Console/stubs/crud-operation.stub
+++ b/src/Console/stubs/crud-operation.stub
@@ -3,6 +3,7 @@
 namespace DummyNamespace;
 
 use Illuminate\Support\Facades\Route;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
 
 trait DummyClassOperation
 {
@@ -15,10 +16,10 @@ trait DummyClassOperation
      */
     protected function setupDummyClassRoutes($segment, $routeName, $controller)
     {
-        Route::get($segment.'/dummy_class', [
-            'as'        => $routeName.'.dummy_class',
-            'uses'      => $controller.'@dummy_class',
-            'operation' => 'DummyClass',
+        Route::get($segment.'/dummy-class', [
+            'as'        => $routeName.'.dummyClass',
+            'uses'      => $controller.'@dummyClass',
+            'operation' => 'dummyClass',
         ]);
     }
 
@@ -27,15 +28,15 @@ trait DummyClassOperation
      */
     protected function setupDummyClassDefaults()
     {
-        $this->crud->allowAccess('DummyClass');
+        CRUD::allowAccess('dummyClass');
 
-        $this->crud->operation('DummyClass', function () {
-            $this->crud->loadDefaultOperationSettingsFromConfig();
+        CRUD::operation('dummyClass', function () {
+            CRUD::loadDefaultOperationSettingsFromConfig();
         });
 
-        $this->crud->operation('list', function () {
-            // $this->crud->addButton('top', 'dummy_class', 'view', 'crud::buttons.dummy_class');
-            // $this->crud->addButton('line', 'dummy_class', 'view', 'crud::buttons.dummy_class');
+        CRUD::operation('list', function () {
+            // CRUD::addButton('top', 'dummy_class', 'view', 'crud::buttons.dummy_class');
+            // CRUD::addButton('line', 'dummy_class', 'view', 'crud::buttons.dummy_class');
         });
     }
 
@@ -44,15 +45,15 @@ trait DummyClassOperation
      *
      * @return Response
      */
-    public function dummy_class()
+    public function dummyClass()
     {
-        $this->crud->hasAccessOrFail('DummyClass');
+        CRUD::hasAccessOrFail('dummyClass');
 
         // prepare the fields you need to show
         $this->data['crud'] = $this->crud;
-        $this->data['title'] = $this->crud->getTitle() ?? 'dummy_class '.$this->crud->entity_name;
+        $this->data['title'] = CRUD::getTitle() ?? 'Dummy Class '.$this->crud->entity_name;
 
         // load the view
-        return view("crud::operations.dummy_class", $this->data);
+        return view('crud::operations.dummy_class', $this->data);
     }
 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

An operation with name `BrowserPrint` would become `browserprint` as operation name in stub. I think it's unexpected, we should keep using the `BrowserPrint` name, since it's the name developer gave to the operation when creating it in console.