### PR TITLE
Command to create a new page

### DIFF
--- a/src/Console/Commands/PageBackpackCommand.php
+++ b/src/Console/Commands/PageBackpackCommand.php
@@ -118,8 +118,7 @@ class PageBackpackCommand extends GeneratorCommand
     /**
      * Determine if the class already exists.
      *
-     * @param string $name
-     *
+     * @param  string  $name
      * @return bool
      */
     protected function alreadyExists($name)
@@ -130,8 +129,7 @@ class PageBackpackCommand extends GeneratorCommand
     /**
      * Get the destination class path.
      *
-     * @param string $name
-     *
+     * @param  string  $name
      * @return string
      */
     protected function getPath($name)

--- a/src/Console/Commands/PageBackpackCommand.php
+++ b/src/Console/Commands/PageBackpackCommand.php
@@ -48,24 +48,26 @@ class PageBackpackCommand extends GeneratorCommand
      */
     public function handle()
     {
-        $filePath = Str::of($this->getNameInput())
+        $input = Str::of($this->getNameInput())
             ->replace('\\', '/')
             ->replace('.', '/')
-            ->trim('/')
             ->start('/')
-            ->prepend($this->option('view-path'));
+            ->prepend($this->option('view-path'))
+            ->replace('//', '/')
+            ->trim('/');
 
-        $name = $filePath->afterLast('/');
-        $path = $filePath->beforeLast('/');
+        $name = $input->afterLast('/')->replace('-', '_')->snake();
+        $path = $input->beforeLast('/');
+        $filePath = "$path/$name";
         $fullpath = $this->getPath($filePath);
         $layout = $this->option('layout');
 
-        $this->infoBlock("Creating {$name->title()} page");
+        $this->infoBlock("Creating {$name->replace('_', ' ')->title()} page");
 
         $this->progressBlock("Creating view <fg=blue>resources/views/${filePath}.php</>");
 
         // check if the file already exists
-        if ((! $this->hasOption('force') || ! $this->option('force')) && $this->alreadyExists($fullpath)) {
+        if ((! $this->hasOption('force') || ! $this->option('force')) && $this->alreadyExists($filePath)) {
             $this->closeProgressBlock('Already existed', 'yellow');
 
             return false;

--- a/src/Console/Commands/PageBackpackCommand.php
+++ b/src/Console/Commands/PageBackpackCommand.php
@@ -64,7 +64,7 @@ class PageBackpackCommand extends GeneratorCommand
 
         $this->infoBlock("Creating {$name->replace('_', ' ')->title()} page");
 
-        $this->progressBlock("Creating view <fg=blue>resources/views/${filePath}.php</>");
+        $this->progressBlock("Creating view <fg=blue>resources/views/${filePath}.blade.php</>");
 
         // check if the file already exists
         if ((! $this->hasOption('force') || ! $this->option('force')) && $this->alreadyExists($filePath)) {
@@ -78,10 +78,13 @@ class PageBackpackCommand extends GeneratorCommand
         // create page view
         $stub = $this->buildClass($filePath);
         $stub = str_replace('layout', $layout, $stub);
-        $stub = str_replace('DummyName', $name->studly(), $stub);
+        $stub = str_replace('Dummy Name', $name->replace('_', ' ')->title(), $stub);
         $this->files->put($fullpath, $stub);
 
         $this->closeProgressBlock();
+
+        // Clean up name
+        $name = $name->replace('_', ' ')->replace('-', ' ')->title();
 
         // create controller
         $this->call('backpack:page-controller', [
@@ -96,13 +99,13 @@ class PageBackpackCommand extends GeneratorCommand
 
         // create the sidebar item
         $this->call('backpack:add-sidebar-content', [
-            'code' => "<li class=\"nav-item\"><a class=\"nav-link\" href=\"{{ backpack_url('{$name->kebab()}') }}\"><i class=\"nav-icon la la-question\"></i> {$name->title()}</a></li>",
+            'code' => "<li class=\"nav-item\"><a class=\"nav-link\" href=\"{{ backpack_url('{$name->kebab()}') }}\"><i class=\"nav-icon la la-question\"></i> {$name}</a></li>",
         ]);
 
         $url = Str::of(config('app.url'))->finish('/')->append("admin/{$name->kebab()}");
 
         $this->newLine();
-        $this->note("Page {$name->title()} created.");
+        $this->note("Page {$name} created.");
         $this->note("Go to <fg=blue>$url</> to access your new page.");
         $this->newLine();
     }

--- a/src/Console/Commands/PageBackpackCommand.php
+++ b/src/Console/Commands/PageBackpackCommand.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Backpack\Generators\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+
+class PageBackpackCommand extends GeneratorCommand
+{
+    use \Backpack\CRUD\app\Console\Commands\Traits\PrettyCommandOutput;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'backpack:page';
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backpack:page {name} 
+        {--view-path=admin : Path for the view, after resources/views/}
+        {--layout= : Base layout for the page}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate a Backpack Page';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Resource';
+
+    /**
+     * Execute the console command.
+     *
+     * @return bool|null
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    public function handle()
+    {
+        $filePath = Str::of($this->getNameInput())
+            ->replace('\\', '/')
+            ->replace('.', '/')
+            ->trim('/')
+            ->start('/')
+            ->prepend($this->option('view-path'));
+
+        $name = $filePath->afterLast('/');
+        $path = $filePath->beforeLast('/');
+        $fullpath = $this->getPath($filePath);
+        $layout = $this->option('layout');
+
+        $this->infoBlock("Creating {$name->title()} page");
+
+        $this->progressBlock("Creating view <fg=blue>resources/views/${filePath}.php</>");
+
+        // check if the file already exists
+        if ((! $this->hasOption('force') || ! $this->option('force')) && $this->alreadyExists($fullpath)) {
+            $this->closeProgressBlock('Already existed', 'yellow');
+
+            return false;
+        }
+
+        $this->makeDirectory($fullpath);
+
+        // create page view
+        $stub = $this->buildClass($filePath);
+        $stub = str_replace('layout', $layout, $stub);
+        $stub = str_replace('DummyName', $name->studly(), $stub);
+        $this->files->put($fullpath, $stub);
+
+        $this->closeProgressBlock();
+
+        // create controller
+        $this->call('backpack:page-controller', [
+            'name' => $name,
+            '--view-path' => $path,
+        ]);
+
+        // create route
+        $this->call('backpack:add-custom-route', [
+            'code' => "Route::get('{$name->kebab()}', '{$name->studly()}Controller@index')->name('page.{$name->kebab()}.index');",
+        ]);
+
+        // create the sidebar item
+        $this->call('backpack:add-sidebar-content', [
+            'code' => "<li class=\"nav-item\"><a class=\"nav-link\" href=\"{{ backpack_url('{$name->kebab()}') }}\"><i class=\"nav-icon la la-question\"></i> {$name->title()}</a></li>",
+        ]);
+
+        $url = Str::of(config('app.url'))->finish('/')->append("admin/{$name->kebab()}");
+
+        $this->newLine();
+        $this->note("Page {$name->title()} created.");
+        $this->note("Go to <fg=blue>$url</> to access your new page.");
+        $this->newLine();
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/../stubs/page.stub';
+    }
+
+    /**
+     * Determine if the class already exists.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    protected function alreadyExists($name)
+    {
+        return $this->files->exists($this->getPath($name));
+    }
+
+    /**
+     * Get the destination class path.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        return resource_path("views/$name.blade.php");
+    }
+}

--- a/src/Console/Commands/PageControllerBackpackCommand.php
+++ b/src/Console/Commands/PageControllerBackpackCommand.php
@@ -132,10 +132,11 @@ class PageControllerBackpackCommand extends GeneratorCommand
      */
     protected function replacePathStrings(&$stub)
     {
+        $viewName = $this->getNameInput()->snake('_');
         $pathDot = Str::of($this->option('view-path'))
             ->replace('/', '.')
             ->replace('\\', '.')
-            ->append('.'.$this->getNameInput()->lcfirst())
+            ->append('.'.$viewName)
             ->trim('.');
         $pathSlash = $pathDot->replace('.', '/');
 
@@ -158,6 +159,7 @@ class PageControllerBackpackCommand extends GeneratorCommand
 
         $stub = str_replace('DummyName', $name, $stub);
         $stub = str_replace('dummyName', $name->lcfirst(), $stub);
+        $stub = str_replace('Dummy Name', $name->kebab()->replace('-', ' ')->title(), $stub);
 
         return $this;
     }

--- a/src/Console/Commands/PageControllerBackpackCommand.php
+++ b/src/Console/Commands/PageControllerBackpackCommand.php
@@ -47,25 +47,25 @@ class PageControllerBackpackCommand extends GeneratorCommand
     public function handle()
     {
         $name = $this->getNameInput();
-        $this->progressBlock("Creating controller <fg=blue>${name}Controller</>");
+        $class = $this->qualifyClass($name);
+        $fullPath = $this->getPath($class);
+        $path = Str::of($fullPath)->after(base_path())->trim('\\/');
 
-        if ($this->isReservedName($this->getNameInput())) {
+        $this->progressBlock("Creating controller <fg=blue>{$path}</>");
+
+        if ($this->isReservedName($name)) {
             $this->errorProgressBlock();
             $this->note("The name '$name' is reserved by PHP.", 'red');
 
             return false;
         }
 
-        $name = $this->qualifyClass($this->getNameInput());
-
-        $path = $this->getPath($name);
-
         // Next, We will check to see if the class already exists. If it does, we don't want
         // to create the class and overwrite the user's code. So, we will bail out so the
         // code is untouched. Otherwise, we will continue generating this class' files.
         if ((! $this->hasOption('force') ||
             ! $this->option('force')) &&
-            $this->alreadyExists($this->getNameInput())) {
+            $this->alreadyExists($class)) {
             $this->closeProgressBlock('Already existed', 'yellow');
 
             return false;
@@ -74,9 +74,9 @@ class PageControllerBackpackCommand extends GeneratorCommand
         // Next, we will generate the path to the location where this class' file should get
         // written. Then, we will build the class and make the proper replacements on the
         // stub files so that it gets the correctly formatted namespace and class name.
-        $this->makeDirectory($path);
+        $this->makeDirectory($fullPath);
 
-        $this->files->put($path, $this->sortImports($this->buildClass($name)));
+        $this->files->put($fullPath, $this->sortImports($this->buildClass($class)));
 
         $this->closeProgressBlock();
     }

--- a/src/Console/Commands/PageControllerBackpackCommand.php
+++ b/src/Console/Commands/PageControllerBackpackCommand.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Backpack\Generators\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+
+class PageControllerBackpackCommand extends GeneratorCommand
+{
+    use \Backpack\CRUD\app\Console\Commands\Traits\PrettyCommandOutput;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'backpack:page-controller';
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backpack:page-controller {name} {--view-path=}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate a Backpack PageController';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Controller';
+
+    /**
+     * Execute the console command.
+     *
+     * @return bool|null
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    public function handle()
+    {
+        $name = $this->getNameInput();
+        $this->progressBlock("Creating controller <fg=blue>${name}Controller</>");
+
+        if ($this->isReservedName($this->getNameInput())) {
+            $this->errorProgressBlock();
+            $this->note("The name '$name' is reserved by PHP.", 'red');
+
+            return false;
+        }
+
+        $name = $this->qualifyClass($this->getNameInput());
+
+        $path = $this->getPath($name);
+
+        // Next, We will check to see if the class already exists. If it does, we don't want
+        // to create the class and overwrite the user's code. So, we will bail out so the
+        // code is untouched. Otherwise, we will continue generating this class' files.
+        if ((! $this->hasOption('force') ||
+            ! $this->option('force')) &&
+            $this->alreadyExists($this->getNameInput())) {
+            $this->closeProgressBlock('Already existed', 'yellow');
+
+            return false;
+        }
+
+        // Next, we will generate the path to the location where this class' file should get
+        // written. Then, we will build the class and make the proper replacements on the
+        // stub files so that it gets the correctly formatted namespace and class name.
+        $this->makeDirectory($path);
+
+        $this->files->put($path, $this->sortImports($this->buildClass($name)));
+
+        $this->closeProgressBlock();
+    }
+
+    /**
+     * Get the desired class name from the input.
+     *
+     * @return string
+     */
+    protected function getNameInput()
+    {
+        return Str::of($this->argument('name'))->trim()->studly();
+    }
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        return str_replace('.php', 'Controller.php', parent::getPath($name));
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/../stubs/page-controller.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Http\Controllers\Admin';
+    }
+
+    /**
+     * Replace the path name for the given stub.
+     *
+     * @param  string  $stub
+     * @param  string  $name
+     * @return string
+     */
+    protected function replacePathStrings(&$stub)
+    {
+        $pathDot = Str::of($this->option('view-path'))
+            ->replace('/', '.')
+            ->replace('\\', '.')
+            ->append('.'.$this->getNameInput()->lcfirst())
+            ->trim('.');
+        $pathSlash = $pathDot->replace('.', '/');
+
+        $stub = str_replace('dummy.path', $pathDot, $stub);
+        $stub = str_replace('dummy/path', $pathSlash, $stub);
+
+        return $this;
+    }
+
+    /**
+     * Replace the name for the given stub.
+     *
+     * @param  string  $stub
+     * @param  string  $name
+     * @return string
+     */
+    protected function replaceNameStrings(&$stub)
+    {
+        $name = $this->getNameInput();
+
+        $stub = str_replace('DummyName', $name, $stub);
+        $stub = str_replace('dummyName', $name->lcfirst(), $stub);
+
+        return $this;
+    }
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = $this->files->get($this->getStub());
+
+        return $this
+            ->replaceNamespace($stub, $name)
+            ->replacePathStrings($stub)
+            ->replaceNameStrings($stub)
+            ->replaceClass($stub, $name);
+    }
+}

--- a/src/Console/stubs/page-controller.stub
+++ b/src/Console/stubs/page-controller.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace DummyNamespace;
+
+use Backpack\CRUD\app\Http\Controllers\BaseController;
+
+/**
+ * Class DummyClassController
+ * @package App\Http\Controllers\Admin
+ * @property-read \Backpack\CRUD\app\Library\CrudPanel\CrudPanel $crud
+ */
+class DummyClassController extends BaseController
+{
+    public function index()
+    {
+        return view('dummy.path', [
+            'title' => 'DummyName',
+            'breadcrumbs' => [
+                trans('backpack::crud.admin') => backpack_url('dashboard'),
+                'DummyName' => false,
+            ],
+            'page' => 'resources/views/dummy/path.blade.php',
+            'controller' => 'app/Http/Controllers/Admin/DummyNameController.php',
+        ]);
+    }
+}

--- a/src/Console/stubs/page-controller.stub
+++ b/src/Console/stubs/page-controller.stub
@@ -14,7 +14,7 @@ class DummyClassController extends Controller
     public function index()
     {
         return view('dummy.path', [
-            'title' => 'DummyName',
+            'title' => 'Dummy Name',
             'breadcrumbs' => [
                 trans('backpack::crud.admin') => backpack_url('dashboard'),
                 'DummyName' => false,

--- a/src/Console/stubs/page-controller.stub
+++ b/src/Console/stubs/page-controller.stub
@@ -2,14 +2,14 @@
 
 namespace DummyNamespace;
 
-use Backpack\CRUD\app\Http\Controllers\BaseController;
+use Illuminate\Routing\Controller;
 
 /**
  * Class DummyClassController
  * @package App\Http\Controllers\Admin
  * @property-read \Backpack\CRUD\app\Library\CrudPanel\CrudPanel $crud
  */
-class DummyClassController extends BaseController
+class DummyClassController extends Controller
 {
     public function index()
     {

--- a/src/Console/stubs/page.stub
+++ b/src/Console/stubs/page.stub
@@ -2,7 +2,7 @@
 
 @section('content')
 <div class="jumbotron">
-    <h1 class="mb-4">DummyName</h1>
+    <h1 class="mb-4">Dummy Name</h1>
 
     <p>Go to <code>{{ $page }}</code> to edit this view or <code>{{ $controller }}</code> to edit the controller.</p>
 </div>

--- a/src/Console/stubs/page.stub
+++ b/src/Console/stubs/page.stub
@@ -4,7 +4,6 @@
 <div class="jumbotron">
     <h1 class="mb-4">DummyName</h1>
 
-    <p>Go to <code>{{ $page }}</code> to edit this page.</p>
-    <p>To add logic to it, go to <code>{{ $controller }}</code> to edit the controller.</p>
+    <p>Go to <code>{{ $page }}</code> to edit this view or <code>{{ $controller }}</code> to edit the controller.</p>
 </div>
 @endsection

--- a/src/Console/stubs/page.stub
+++ b/src/Console/stubs/page.stub
@@ -1,0 +1,10 @@
+@extends(backpack_view('blank'))
+
+@section('content')
+<div class="jumbotron">
+    <h1 class="mb-4">DummyName</h1>
+
+    <p>Go to <code>{{ $page }}</code> to edit this page.</p>
+    <p>To add logic to it, go to <code>{{ $controller }}</code> to edit the controller.</p>
+</div>
+@endsection

--- a/src/GeneratorsServiceProvider.php
+++ b/src/GeneratorsServiceProvider.php
@@ -12,6 +12,8 @@ use Backpack\Generators\Console\Commands\CrudModelBackpackCommand;
 use Backpack\Generators\Console\Commands\CrudOperationBackpackCommand;
 use Backpack\Generators\Console\Commands\CrudRequestBackpackCommand;
 use Backpack\Generators\Console\Commands\ModelBackpackCommand;
+use Backpack\Generators\Console\Commands\PageBackpackCommand;
+use Backpack\Generators\Console\Commands\PageControllerBackpackCommand;
 use Backpack\Generators\Console\Commands\RequestBackpackCommand;
 use Backpack\Generators\Console\Commands\ViewBackpackCommand;
 use Illuminate\Support\ServiceProvider;
@@ -29,6 +31,8 @@ class GeneratorsServiceProvider extends ServiceProvider
         CrudBackpackCommand::class,
         ChartBackpackCommand::class,
         ModelBackpackCommand::class,
+        PageBackpackCommand::class,
+        PageControllerBackpackCommand::class,
         RequestBackpackCommand::class,
         ViewBackpackCommand::class,
     ];


### PR DESCRIPTION
Fixes #138.

![image](https://user-images.githubusercontent.com/1838187/186026031-8b157a23-937c-4f16-b93f-eed535a7469c.png)

## WHY

### AFTER - What is happening after this PR?

Developers can run;

```cmd
php artisan backpack:page status
```
```cmd
php artisan backpack:page portugal --view-path=status --layout=blank
```

This will also work (thanks to @pxpm suggestion);
```cmd
php artisan backpack:page status.romania
```

<img width="790" alt="image" src="https://user-images.githubusercontent.com/1838187/186027013-31466cf1-69a1-4a6b-a435-5b6c88215c78.png">



`--view-path` defaults to `admin`, but devs are free to change it.
`--layout` also defaults to `blank`.
Later we may add `--controller-path`.
