### PR TITLE
Create a php artisan backpack:button command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ php artisan backpack:view {Entity_name}
 php artisan backpack:config {Entity_name}
 ```
 
+- Generate a button
+
+``` bash
+php artisan backpack:button {Entity_name}
+```
+
 ## Change log
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/src/Console/Commands/ButtonBackpackCommand.php
+++ b/src/Console/Commands/ButtonBackpackCommand.php
@@ -97,7 +97,7 @@ class ButtonBackpackCommand extends GeneratorCommand
      * @return string
      */
     protected function getPath($name)
-    {        
+    {
         return $this->laravel['path'].'/../resources/views/vendor/backpack/crud/buttons/'.str_replace('\\', '/', $name).'.blade.php';
     }
 
@@ -111,6 +111,7 @@ class ButtonBackpackCommand extends GeneratorCommand
     {
         $stub = $this->files->get($this->getStub());
         $stub = str_replace('dummy', $name, $stub);
+        
         return $stub;
     }
 

--- a/src/Console/Commands/ButtonBackpackCommand.php
+++ b/src/Console/Commands/ButtonBackpackCommand.php
@@ -3,9 +3,11 @@
 namespace Backpack\Generators\Console\Commands;
 
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
 
 class ButtonBackpackCommand extends GeneratorCommand
 {
+    use \Backpack\CRUD\app\Console\Commands\Traits\PrettyCommandOutput;
     /**
      * The console command name.
      *
@@ -62,8 +64,7 @@ class ButtonBackpackCommand extends GeneratorCommand
      */
     public function fire()
     {
-        $name = $this->getNameInput();
-
+        $name = Str::of($this->getNameInput());
         $path = $this->getPath($name);
 
         if ($this->alreadyExists($this->getNameInput())) {
@@ -72,10 +73,14 @@ class ButtonBackpackCommand extends GeneratorCommand
             return false;
         }
 
+        $this->infoBlock("Creating {$name->replace('_', ' ')->title()} {$this->type}");
+        $this->progressBlock("Creating view <fg=blue>${path}.blade.php</>");
+
         $this->makeDirectory($path);
-
         $this->files->put($path, $this->buildClass($name));
-
+        
+        $this->closeProgressBlock();
+        $this->newLine();
         $this->info($this->type.' created successfully.');
     }
 
@@ -98,7 +103,7 @@ class ButtonBackpackCommand extends GeneratorCommand
      */
     protected function getPath($name)
     {
-        return $this->laravel['path'].'/../resources/views/vendor/backpack/crud/buttons/'.str_replace('\\', '/', $name).'.blade.php';
+        return resource_path("views/vendor/backpack/crud/buttons/$name.blade.php");        
     }
 
     /**

--- a/src/Console/Commands/ButtonBackpackCommand.php
+++ b/src/Console/Commands/ButtonBackpackCommand.php
@@ -65,7 +65,7 @@ class ButtonBackpackCommand extends GeneratorCommand
     public function fire()
     {
         $name = Str::of($this->getNameInput());
-        $path = $this->getPath($name);
+        $path = $this->getPath($name);        
 
         if ($this->alreadyExists($this->getNameInput())) {
             $this->error($this->type.' already existed!');
@@ -74,7 +74,7 @@ class ButtonBackpackCommand extends GeneratorCommand
         }
 
         $this->infoBlock("Creating {$name->replace('_', ' ')->title()} {$this->type}");
-        $this->progressBlock("Creating view <fg=blue>${path}.blade.php</>");
+        $this->progressBlock("Creating view <fg=blue>resources/views/vendor/backpack/crud/buttons/${name}.blade.php</>");
 
         $this->makeDirectory($path);
         $this->files->put($path, $this->buildClass($name));

--- a/src/Console/Commands/ButtonBackpackCommand.php
+++ b/src/Console/Commands/ButtonBackpackCommand.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Backpack\Generators\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+
+class ButtonBackpackCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'backpack:button';
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backpack:button {name}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate a backpack templated button';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Button';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/../stubs/button.stub';
+    }
+
+    /**
+     * Alias for the fire method.
+     *
+     * In Laravel 5.5 the fire() method has been renamed to handle().
+     * This alias provides support for both Laravel 5.4 and 5.5.
+     */
+    public function handle()
+    {
+        $this->fire();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return bool|null
+     */
+    public function fire()
+    {
+        $name = $this->getNameInput();
+
+        $path = $this->getPath($name);
+
+        if ($this->alreadyExists($this->getNameInput())) {
+            $this->error($this->type.' already existed!');
+
+            return false;
+        }
+
+        $this->makeDirectory($path);
+
+        $this->files->put($path, $this->buildClass($name));
+
+        $this->info($this->type.' created successfully.');
+    }
+
+    /**
+     * Determine if the class already exists.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    protected function alreadyExists($name)
+    {
+        return $this->files->exists($this->getPath($name));
+    }
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {        
+        return $this->laravel['path'].'/../resources/views/vendor/backpack/crud/buttons/'.str_replace('\\', '/', $name).'.blade.php';
+    }
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = $this->files->get($this->getStub());
+        $stub = str_replace('dummy', $name, $stub);
+        return $stub;
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+
+        ];
+    }
+}

--- a/src/Console/Commands/ButtonBackpackCommand.php
+++ b/src/Console/Commands/ButtonBackpackCommand.php
@@ -25,7 +25,7 @@ class ButtonBackpackCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $description = 'Generate a backpack templated button';
+    protected $description = 'Generate a Backpack button';
 
     /**
      * The type of class being generated.

--- a/src/Console/stubs/button.stub
+++ b/src/Console/stubs/button.stub
@@ -1,3 +1,3 @@
 @if ($crud->hasAccess('dummy'))
-  <a href="{{ url($crud->route.'/'.$entry->getKey().'/dummy') }}" class="btn btn-sm btn-link text-capitalize"><i class="la la-question"></i> Dummy</a>
+  <a href="{{ url($crud->route.'/'.$entry->getKey().'/dummy') }}" class="btn btn-sm btn-link text-capitalize"><i class="la la-question"></i> dummy</a>
 @endif

--- a/src/Console/stubs/button.stub
+++ b/src/Console/stubs/button.stub
@@ -1,0 +1,3 @@
+@if ($crud->hasAccess('dummy'))
+  <a href="{{ url($crud->route.'/'.$entry->getKey().'/dummy') }}" class="btn btn-sm btn-link text-capitalize"><i class="la la-envelope"></i> dummy</a>
+@endif

--- a/src/Console/stubs/button.stub
+++ b/src/Console/stubs/button.stub
@@ -1,3 +1,3 @@
 @if ($crud->hasAccess('dummy'))
-  <a href="{{ url($crud->route.'/'.$entry->getKey().'/dummy') }}" class="btn btn-sm btn-link text-capitalize"><i class="la la-envelope"></i> dummy</a>
+  <a href="{{ url($crud->route.'/'.$entry->getKey().'/dummy') }}" class="btn btn-sm btn-link text-capitalize"><i class="la la-question"></i> Dummy</a>
 @endif

--- a/src/GeneratorsServiceProvider.php
+++ b/src/GeneratorsServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Backpack\Generators;
 
 use Backpack\Generators\Console\Commands\BuildBackpackCommand;
+use Backpack\Generators\Console\Commands\ButtonBackpackCommand;
 use Backpack\Generators\Console\Commands\ChartBackpackCommand;
 use Backpack\Generators\Console\Commands\ChartControllerBackpackCommand;
 use Backpack\Generators\Console\Commands\ConfigBackpackCommand;
@@ -14,13 +15,13 @@ use Backpack\Generators\Console\Commands\CrudRequestBackpackCommand;
 use Backpack\Generators\Console\Commands\ModelBackpackCommand;
 use Backpack\Generators\Console\Commands\RequestBackpackCommand;
 use Backpack\Generators\Console\Commands\ViewBackpackCommand;
-use Backpack\Generators\Console\Commands\ButtonBackpackCommand;
 use Illuminate\Support\ServiceProvider;
 
 class GeneratorsServiceProvider extends ServiceProvider
 {
     protected $commands = [
         BuildBackpackCommand::class,
+        ButtonBackpackCommand::class,
         ConfigBackpackCommand::class,
         CrudModelBackpackCommand::class,
         CrudControllerBackpackCommand::class,
@@ -31,8 +32,7 @@ class GeneratorsServiceProvider extends ServiceProvider
         ChartBackpackCommand::class,
         ModelBackpackCommand::class,
         RequestBackpackCommand::class,
-        ViewBackpackCommand::class,
-        ButtonBackpackCommand::class,
+        ViewBackpackCommand::class,        
     ];
 
     /**

--- a/src/GeneratorsServiceProvider.php
+++ b/src/GeneratorsServiceProvider.php
@@ -32,7 +32,7 @@ class GeneratorsServiceProvider extends ServiceProvider
         ChartBackpackCommand::class,
         ModelBackpackCommand::class,
         RequestBackpackCommand::class,
-        ViewBackpackCommand::class,        
+        ViewBackpackCommand::class,
     ];
 
     /**

--- a/src/GeneratorsServiceProvider.php
+++ b/src/GeneratorsServiceProvider.php
@@ -14,6 +14,7 @@ use Backpack\Generators\Console\Commands\CrudRequestBackpackCommand;
 use Backpack\Generators\Console\Commands\ModelBackpackCommand;
 use Backpack\Generators\Console\Commands\RequestBackpackCommand;
 use Backpack\Generators\Console\Commands\ViewBackpackCommand;
+use Backpack\Generators\Console\Commands\ButtonBackpackCommand;
 use Illuminate\Support\ServiceProvider;
 
 class GeneratorsServiceProvider extends ServiceProvider
@@ -31,6 +32,7 @@ class GeneratorsServiceProvider extends ServiceProvider
         ModelBackpackCommand::class,
         RequestBackpackCommand::class,
         ViewBackpackCommand::class,
+        ButtonBackpackCommand::class,
     ];
 
     /**


### PR DESCRIPTION
New Feature:
What I did:
Created an operation, had no way to create a custom button really quick (with a stub).

What happens:
Run php artisan backpack:button email and it would create the button for me.