### PR TITLE
Converted namespaces into file links on backpack:crud command

### DIFF
--- a/src/Console/Commands/CrudControllerBackpackCommand.php
+++ b/src/Console/Commands/CrudControllerBackpackCommand.php
@@ -49,8 +49,9 @@ class CrudControllerBackpackCommand extends GeneratorCommand
     {
         $name = $this->qualifyClass($this->getNameInput());
         $path = $this->getPath($name);
-
-        $this->progressBlock("Creating ${name}CrudController");
+        $relativePath = Str::of($path)->after(base_path())->trim('\\/');
+        
+        $this->progressBlock("Creating Controller <fg=blue>$relativePath</>");
 
         // Next, We will check to see if the class already exists. If it does, we don't want
         // to create the class and overwrite the user's code. So, we will bail out so the

--- a/src/Console/Commands/CrudControllerBackpackCommand.php
+++ b/src/Console/Commands/CrudControllerBackpackCommand.php
@@ -50,7 +50,7 @@ class CrudControllerBackpackCommand extends GeneratorCommand
         $name = $this->qualifyClass($this->getNameInput());
         $path = $this->getPath($name);
         $relativePath = Str::of($path)->after(base_path())->trim('\\/');
-        
+
         $this->progressBlock("Creating Controller <fg=blue>$relativePath</>");
 
         // Next, We will check to see if the class already exists. If it does, we don't want

--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -56,8 +56,9 @@ class CrudModelBackpackCommand extends GeneratorCommand
         $name = $this->getNameInput();
         $namespaceApp = $this->qualifyClass($this->getNameInput());
         $namespaceModels = $this->qualifyClass('/Models/'.$this->getNameInput());
+        $relativePath = Str::of("$namespaceModels.php")->lcfirst()->replace('\\', '/');
 
-        $this->progressBlock("Creating $namespaceModels");
+        $this->progressBlock("Creating Model <fg=blue>$relativePath</>");
 
         // Check if exists on app or models
         $existsOnApp = $this->alreadyExists($namespaceApp);
@@ -97,7 +98,7 @@ class CrudModelBackpackCommand extends GeneratorCommand
         // As the class already exists, we don't want to create the class and overwrite the
         // user's code. We just make sure it uses CrudTrait. We add that one line.
         if (! $this->hasOption('force') || ! $this->option('force')) {
-            $this->progressBlock('Adding CrudTrait to model');
+            $this->progressBlock('Adding CrudTrait to the Model');
 
             $file = $this->files->get($path);
             $lines = preg_split('/(\r\n)|\r|\n/', $file);

--- a/src/Console/Commands/CrudRequestBackpackCommand.php
+++ b/src/Console/Commands/CrudRequestBackpackCommand.php
@@ -3,6 +3,7 @@
 namespace Backpack\Generators\Console\Commands;
 
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
 
 class CrudRequestBackpackCommand extends GeneratorCommand
 {
@@ -47,8 +48,9 @@ class CrudRequestBackpackCommand extends GeneratorCommand
     {
         $name = $this->qualifyClass($this->getNameInput());
         $path = $this->getPath($name);
+        $relativePath = Str::of($path)->after(base_path())->trim('\\/');
 
-        $this->progressBlock("Creating ${name}Request");
+        $this->progressBlock("Creating Request <fg=blue>$relativePath</>");
 
         // Next, We will check to see if the class already exists. If it does, we don't want
         // to create the class and overwrite the user's code. So, we will bail out so the


### PR DESCRIPTION
Fixes https://github.com/Laravel-Backpack/Generators/issues/139.

## WHY

### BEFORE - What was wrong? What was happening before this PR?

Message for the generated Model, Controller and Request was using the namespace instead of the file link.

### AFTER - What is happening after this PR?

All generated files are now with relative paths;

![image](https://user-images.githubusercontent.com/1838187/188321485-7ec180b6-48c2-4e12-ba1e-edbb07833451.png)

### Is it a breaking change or non-breaking change?

No 👌


### How can we test the before & after?

Run `php artisan backpack:crud user`.
