### PR TITLE
Fixed CRUD Controller generated fields and columns

### DIFF
--- a/src/Console/Commands/CrudControllerBackpackCommand.php
+++ b/src/Console/Commands/CrudControllerBackpackCommand.php
@@ -161,26 +161,27 @@ class CrudControllerBackpackCommand extends GeneratorCommand
         }
 
         $attributes = $this->getAttributes($model);
+        $fields = array_diff($attributes, ['id', 'created_at', 'updated_at', 'deleted_at']);
+        $columns = array_diff($attributes, ['id']);
+        $glue = PHP_EOL.'        ';
 
         // create an array with the needed code for defining fields
-        $fields = Arr::except($attributes, ['id', 'created_at', 'updated_at', 'deleted_at']);
         $fields = collect($fields)
             ->map(function ($field) {
                 return "CRUD::field('$field');";
             })
-            ->toArray();
+            ->join($glue);
 
         // create an array with the needed code for defining columns
-        $columns = Arr::except($attributes, ['id']);
         $columns = collect($columns)
             ->map(function ($column) {
                 return "CRUD::column('$column');";
             })
-            ->toArray();
+            ->join($glue);
 
         // replace setFromDb with actual fields and columns
-        $stub = str_replace('CRUD::setFromDb(); // fields', implode(PHP_EOL.'        ', $fields), $stub);
-        $stub = str_replace('CRUD::setFromDb(); // columns', implode(PHP_EOL.'        ', $columns), $stub);
+        $stub = str_replace('CRUD::setFromDb(); // fields', $fields, $stub);
+        $stub = str_replace('CRUD::setFromDb(); // columns', $columns, $stub);
 
         return $this;
     }

--- a/src/Console/Commands/CrudControllerBackpackCommand.php
+++ b/src/Console/Commands/CrudControllerBackpackCommand.php
@@ -3,7 +3,6 @@
 namespace Backpack\Generators\Console\Commands;
 
 use Illuminate\Console\GeneratorCommand;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 class CrudControllerBackpackCommand extends GeneratorCommand


### PR DESCRIPTION
Fixes https://github.com/Laravel-Backpack/Generators/issues/131.

- [x] MUST - there must NOT be an ID **field** there; that's super-deceiving; don't see a purpose for an ID **column** either; when this this start happening?
- [x] SHOULD - there should probably not be **fields** for created_at and updated_at; who uses that? why did these appear, I don't think they did before;
- [x] SHOULD - fields & columns should appear in the order they're in in the database/migration/smth, not in alphabetical order like they seem to be doing now;

@tabacitu In my case the fields/columns are ordered accordingly to the database.
Can you test on your side? Because I haven't done nothing to fix it, it may be an issue on your side onyl.

If it is, we are reading the values from DB with `Schema::getColumnListing`.
I saw some doing `DB::select("SELECT column_name FROM information_schema.columns WHERE table_name = 'table_name' ORDER BY ordinal_position")`.

Let me know 1st if you still have the issue, (and if so) 2nd if you think we should change to that approach above 👌