### PR TITLE
[BugFix] avoid backpack:build to generate interfaces for abstract models and others

### DIFF
--- a/src/Console/Commands/BuildBackpackCommand.php
+++ b/src/Console/Commands/BuildBackpackCommand.php
@@ -105,7 +105,8 @@ class BuildBackpackCommand extends Command
             if ($reflection->isSubclassOf(Model::class) && ! $reflection->isAbstract()) {
                 return Str::of($class)->afterLast('\\');
             }
-        } catch (\Throwable$e) {}
+        } catch (\Throwable$e) {
+        }
 
         return null;
     }

--- a/src/Console/Commands/BuildBackpackCommand.php
+++ b/src/Console/Commands/BuildBackpackCommand.php
@@ -57,7 +57,7 @@ class BuildBackpackCommand extends Command
         foreach ($results as $result) {
             $filepath = "$path/$result";
 
-            // ignore hidden filed
+            // ignore `.` (dot) prefixed files 
             if ($result[0] === '.') {
                 continue;
             }

--- a/src/Console/Commands/BuildBackpackCommand.php
+++ b/src/Console/Commands/BuildBackpackCommand.php
@@ -57,7 +57,7 @@ class BuildBackpackCommand extends Command
         foreach ($results as $result) {
             $filepath = "$path/$result";
 
-            // ignore `.` (dot) prefixed files 
+            // ignore `.` (dot) prefixed files
             if ($result[0] === '.') {
                 continue;
             }


### PR DESCRIPTION
Fixes https://github.com/Laravel-Backpack/Generators/issues/120.

## WHY

### BEFORE - What was wrong? What was happening before this PR?

`backpack:crud` was generating CRUDs for abstract models, and it was also skipping valid models that simply don't extend **directly** `Illuminate\Database\Eloquent\Model`.

## HOW

### How did you achieve that, in technical terms?

- First it tries to guess the namespace by the file path
- Then it also tries to find the namespace by the file contents.

### Is it a breaking change or non-breaking change?

No.


### How can we test the before & after?

- Having an abstract Model on Models folder (should **not** generate CRUD)
- Having a model that extends another Model or an abstract Model (**should** generate CRUD)

@tabacitu I think I'll ask @pxpm to take a quick look at this one, he is aware of this kind of stuff, requiring files on runtime, guessing namespaces ... he may find something that I should not have done 😅
