### PR TITLE
Default validation as request for the backpack:crud command

### DIFF
--- a/src/Console/Commands/BuildBackpackCommand.php
+++ b/src/Console/Commands/BuildBackpackCommand.php
@@ -15,7 +15,8 @@ class BuildBackpackCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'backpack:build';
+    protected $signature = 'backpack:build
+        {--validation=request : Validation type, must be request, array or field}';
 
     /**
      * The console command description.
@@ -41,7 +42,7 @@ class BuildBackpackCommand extends Command
         }
 
         foreach ($models as $key => $model) {
-            $this->call('backpack:crud', ['name' => $model]);
+            $this->call('backpack:crud', ['name' => $model, '--validation' => $this->option('validation')]);
             $this->line('  <fg=gray>----------</>');
         }
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Since `backpack:crud` now asks for the request type, and `backpack:build` runs dozens of times that command, it is asking the user to input that each time.

<img width="574" alt="image" src="https://user-images.githubusercontent.com/1838187/189166133-3361c679-2085-42c9-afc2-4bc04277f22f.png">

<img width="727" alt="image" src="https://user-images.githubusercontent.com/1838187/189166177-bc2f9fe7-b8d2-4868-903a-500edaa548a8.png">

### AFTER - What is happening after this PR?

This will default the variable to `request`, but also allows adding the variable as an arg of the command.

```php
php artisan backpack:build --validation=field
```

---

I though about adding the question here too, but I don't know if it makes sense, I think this is enough 🤷‍♂️
Let me know @tabacitu 🙌
