### PR TITLE
remove l8 breaking code

### DIFF
--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -56,7 +56,7 @@ class CrudModelBackpackCommand extends GeneratorCommand
         $name = $this->getNameInput();
         $namespaceApp = $this->qualifyClass($this->getNameInput());
         $namespaceModels = $this->qualifyClass('/Models/'.$this->getNameInput());
-        $relativePath = Str::of("$namespaceModels.php")->lcfirst()->replace('\\', '/');
+        $relativePath = lcfirst(Str::of("$namespaceModels.php")->replace('\\', '/'));
 
         $this->progressBlock("Creating Model <fg=blue>$relativePath</>");
 

--- a/src/Console/Commands/PageControllerBackpackCommand.php
+++ b/src/Console/Commands/PageControllerBackpackCommand.php
@@ -4,6 +4,7 @@ namespace Backpack\Generators\Console\Commands;
 
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 
 class PageControllerBackpackCommand extends GeneratorCommand
 {
@@ -84,7 +85,7 @@ class PageControllerBackpackCommand extends GeneratorCommand
     /**
      * Get the desired class name from the input.
      *
-     * @return string
+     * @return Stringable
      */
     protected function getNameInput()
     {
@@ -158,7 +159,7 @@ class PageControllerBackpackCommand extends GeneratorCommand
         $name = $this->getNameInput();
 
         $stub = str_replace('DummyName', $name, $stub);
-        $stub = str_replace('dummyName', $name->lcfirst(), $stub);
+        $stub = str_replace('dummyName', lcfirst($name), $stub);
         $stub = str_replace('Dummy Name', $name->kebab()->replace('-', ' ')->title(), $stub);
 
         return $this;


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported here, stackoverflow etc. 
Str::lcfirst() is not available at L9. 

### AFTER - What is happening after this PR?

we use the native PHP function.


### Is it a breaking change or non-breaking change?

nop


### How can we test the before & after?

try building a CRUD in L8 project.
