### PR TITLE
use the camelcased version of operation name - extended

### DIFF
--- a/src/Console/Commands/CrudOperationBackpackCommand.php
+++ b/src/Console/Commands/CrudOperationBackpackCommand.php
@@ -78,10 +78,13 @@ class CrudOperationBackpackCommand extends GeneratorCommand
      */
     protected function replaceNameStrings(&$stub, $name)
     {
-        $table = Str::plural(ltrim(strtolower(preg_replace('/[A-Z]/', '_$0', str_replace($this->getNamespace($name).'\\', '', $name))), '_'));
+        $name = Str::of($name)->afterLast('\\');
 
-        $stub = str_replace('DummyTable', $table, $stub);
-        $stub = str_replace('dummy_class', strtolower(str_replace($this->getNamespace($name).'\\', '', $name)), $stub);
+        $stub = str_replace('DummyClass', $name->studly(), $stub);
+        $stub = str_replace('dummyClass', $name->lcfirst(), $stub);
+        $stub = str_replace('Dummy Class', $name->snake()->replace('_', ' ')->title(), $stub);
+        $stub = str_replace('dummy-class', $name->snake('-'), $stub);
+        $stub = str_replace('dummy_class', $name->snake(), $stub);
 
         return $this;
     }
@@ -96,7 +99,10 @@ class CrudOperationBackpackCommand extends GeneratorCommand
     {
         $stub = $this->files->get($this->getStub());
 
-        return $this->replaceNamespace($stub, $name)->replaceNameStrings($stub, $name)->replaceClass($stub, $name);
+        return $this
+            ->replaceNamespace($stub, $name)
+            ->replaceNameStrings($stub, $name)
+            ->replaceClass($stub, $name);
     }
 
     /**
@@ -109,5 +115,17 @@ class CrudOperationBackpackCommand extends GeneratorCommand
         return [
 
         ];
+    }
+
+    /**
+     * Get the desired class name from the input.
+     *
+     * @return string
+     */
+    protected function getNameInput()
+    {
+        return Str::of($this->argument('name'))
+            ->trim()
+            ->studly();
     }
 }

--- a/src/Console/stubs/crud-operation.stub
+++ b/src/Console/stubs/crud-operation.stub
@@ -15,10 +15,10 @@ trait DummyClassOperation
      */
     protected function setupDummyClassRoutes($segment, $routeName, $controller)
     {
-        Route::get($segment.'/dummy_class', [
-            'as'        => $routeName.'.dummy_class',
-            'uses'      => $controller.'@dummy_class',
-            'operation' => 'DummyClass',
+        Route::get($segment.'/dummy-class', [
+            'as'        => $routeName.'.dummyClass',
+            'uses'      => $controller.'@dummyClass',
+            'operation' => 'dummyClass',
         ]);
     }
 
@@ -27,9 +27,9 @@ trait DummyClassOperation
      */
     protected function setupDummyClassDefaults()
     {
-        $this->crud->allowAccess('DummyClass');
+        $this->crud->allowAccess('dummyClass');
 
-        $this->crud->operation('DummyClass', function () {
+        $this->crud->operation('dummyClass', function () {
             $this->crud->loadDefaultOperationSettingsFromConfig();
         });
 
@@ -44,13 +44,13 @@ trait DummyClassOperation
      *
      * @return Response
      */
-    public function dummy_class()
+    public function dummyClass()
     {
-        $this->crud->hasAccessOrFail('DummyClass');
+        $this->crud->hasAccessOrFail('dummyClass');
 
         // prepare the fields you need to show
         $this->data['crud'] = $this->crud;
-        $this->data['title'] = $this->crud->getTitle() ?? 'dummy_class '.$this->crud->entity_name;
+        $this->data['title'] = $this->crud->getTitle() ?? 'Dummy Class '.$this->crud->entity_name;
 
         // load the view
         return view("crud::operations.dummy_class", $this->data);

--- a/src/Console/stubs/crud-operation.stub
+++ b/src/Console/stubs/crud-operation.stub
@@ -53,6 +53,6 @@ trait DummyClassOperation
         $this->data['title'] = $this->crud->getTitle() ?? 'Dummy Class '.$this->crud->entity_name;
 
         // load the view
-        return view("crud::operations.dummy_class", $this->data);
+        return view('crud::operations.dummy_class', $this->data);
     }
 }

--- a/src/Console/stubs/crud-operation.stub
+++ b/src/Console/stubs/crud-operation.stub
@@ -3,6 +3,7 @@
 namespace DummyNamespace;
 
 use Illuminate\Support\Facades\Route;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
 
 trait DummyClassOperation
 {
@@ -27,15 +28,15 @@ trait DummyClassOperation
      */
     protected function setupDummyClassDefaults()
     {
-        $this->crud->allowAccess('dummyClass');
+        CRUD::allowAccess('dummyClass');
 
-        $this->crud->operation('dummyClass', function () {
-            $this->crud->loadDefaultOperationSettingsFromConfig();
+        CRUD::operation('dummyClass', function () {
+            CRUD::loadDefaultOperationSettingsFromConfig();
         });
 
-        $this->crud->operation('list', function () {
-            // $this->crud->addButton('top', 'dummy_class', 'view', 'crud::buttons.dummy_class');
-            // $this->crud->addButton('line', 'dummy_class', 'view', 'crud::buttons.dummy_class');
+        CRUD::operation('list', function () {
+            // CRUD::addButton('top', 'dummy_class', 'view', 'crud::buttons.dummy_class');
+            // CRUD::addButton('line', 'dummy_class', 'view', 'crud::buttons.dummy_class');
         });
     }
 
@@ -46,11 +47,11 @@ trait DummyClassOperation
      */
     public function dummyClass()
     {
-        $this->crud->hasAccessOrFail('dummyClass');
+        CRUD::hasAccessOrFail('dummyClass');
 
         // prepare the fields you need to show
         $this->data['crud'] = $this->crud;
-        $this->data['title'] = $this->crud->getTitle() ?? 'Dummy Class '.$this->crud->entity_name;
+        $this->data['title'] = CRUD::getTitle() ?? 'Dummy Class '.$this->crud->entity_name;
 
         // load the view
         return view('crud::operations.dummy_class', $this->data);


### PR DESCRIPTION
This PR is poiting to https://github.com/Laravel-Backpack/Generators/pull/133 from @pxpm.

This extends the changes on `crud-operation` command.

Generated operations are now more similar with the default CRUD operations.

Here is a sample output;

```php
<?php

namespace App\Http\Controllers\Admin\Operations;

use Illuminate\Support\Facades\Route;

trait TestingNameOperation
{
    /**
     * Define which routes are needed for this operation.
     *
     * @param string $segment    Name of the current entity (singular). Used as first URL segment.
     * @param string $routeName  Prefix of the route name.
     * @param string $controller Name of the current CrudController.
     */
    protected function setupTestingNameRoutes($segment, $routeName, $controller)
    {
        Route::get($segment.'/testing-name', [
            'as'        => $routeName.'.testingName',
            'uses'      => $controller.'@testingName',
            'operation' => 'testingName',
        ]);
    }

    /**
     * Add the default settings, buttons, etc that this operation needs.
     */
    protected function setupTestingNameDefaults()
    {
        $this->crud->allowAccess('testingName');

        $this->crud->operation('testingName', function () {
            $this->crud->loadDefaultOperationSettingsFromConfig();
        });

        $this->crud->operation('list', function () {
            // $this->crud->addButton('top', 'testing_name', 'view', 'crud::buttons.testing_name');
            // $this->crud->addButton('line', 'testing_name', 'view', 'crud::buttons.testing_name');
        });
    }

    /**
     * Show the view for performing the operation.
     *
     * @return Response
     */
    public function testingName()
    {
        $this->crud->hasAccessOrFail('testingName');

        // prepare the fields you need to show
        $this->data['crud'] = $this->crud;
        $this->data['title'] = $this->crud->getTitle() ?? 'Testing Name '.$this->crud->entity_name;

        // load the view
        return view("crud::operations.testing_name", $this->data);
    }
}
```

@pxpm, @tabacitu let me know if you agree with the changes.