### PR TITLE
Artisan command to generate new columns

### DIFF
--- a/src/Console/Commands/ColumnBackpackCommand.php
+++ b/src/Console/Commands/ColumnBackpackCommand.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Backpack\Generators\Console\Commands;
+
+use Backpack\CRUD\ViewNamespaces;
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+
+class ColumnBackpackCommand extends GeneratorCommand
+{
+    use \Backpack\CRUD\app\Console\Commands\Traits\PrettyCommandOutput;
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'backpack:column';
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backpack:column {name} {--from=}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate a Backpack column';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Column';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/../stubs/column.stub';
+    }
+
+    /**
+     * Alias for the fire method.
+     *
+     * In Laravel 5.5 the fire() method has been renamed to handle().
+     * This alias provides support for both Laravel 5.4 and 5.5.
+     */
+    public function handle()
+    {
+        $this->fire();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return bool|null
+     */
+    public function fire()
+    {
+        $name = Str::of($this->getNameInput());
+        $path = $this->getPath($name);
+
+        if ($this->alreadyExists($this->getNameInput())) {
+            $this->error("Error : $this->type $name already existed!");
+
+            return false;
+        }
+
+        $src = null;
+        if ($this->option('from')) {
+            $column = Str::of($this->option('from'));
+            $arr = ViewNamespaces::getFor('columns');
+            foreach ($arr as $key => $value) {
+                $viewPath = $value.'.'.$column;
+                if (view()->exists($viewPath)) {
+                    $src = view($viewPath)->getPath();
+                    break;
+                }
+            }
+            if ($src == null) {
+                $this->error("Error : $this->type $column does not exist!");
+
+                return false;
+            }
+        }
+
+        $this->infoBlock("Creating {$name->replace('_', ' ')->title()} {$this->type}");
+        $this->progressBlock("Creating view <fg=blue>resources/views/vendor/backpack/crud/columns/{$name->snake('_')}.blade.php</>");
+
+        $this->makeDirectory($path);
+        if ($src != null) {
+            $this->files->copy($src, $path);
+        } else {
+            $this->files->put($path, $this->buildClass($name));
+        }
+
+        $this->closeProgressBlock();
+        $this->newLine();
+        $this->info($this->type.' created successfully.');
+    }
+
+    /**
+     * Determine if the class already exists.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    protected function alreadyExists($name)
+    {
+        return $this->files->exists($this->getPath($name));
+    }
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        $file = Str::of($name)->snake('_');
+
+        return resource_path("views/vendor/backpack/crud/columns/$file.blade.php");
+    }
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = $this->files->get($this->getStub());       
+
+        return $stub;
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [];
+    }
+}

--- a/src/Console/Commands/ColumnBackpackCommand.php
+++ b/src/Console/Commands/ColumnBackpackCommand.php
@@ -139,7 +139,7 @@ class ColumnBackpackCommand extends GeneratorCommand
      */
     protected function buildClass($name)
     {
-        $stub = $this->files->get($this->getStub());       
+        $stub = $this->files->get($this->getStub());
 
         return $stub;
     }

--- a/src/Console/stubs/column.stub
+++ b/src/Console/stubs/column.stub
@@ -1,0 +1,23 @@
+{{-- regular object attribute --}}
+@php
+    $column['value'] = $column['value'] ?? data_get($entry, $column['name']);    
+    $column['text'] = $column['default'] ?? '-';
+
+    if($column['value'] instanceof \Closure) {
+        $column['value'] = $column['value']($entry);
+    }
+
+    if(is_array($column['value'])) {
+        $column['value'] = json_encode($column['value']);
+    }
+
+    if(!empty($column['value'])) {
+        $column['text'] = $column['value'];
+    }
+@endphp
+
+<span>
+    @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
+        {{ $column['text'] }}
+    @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')
+</span>

--- a/src/GeneratorsServiceProvider.php
+++ b/src/GeneratorsServiceProvider.php
@@ -6,6 +6,7 @@ use Backpack\Generators\Console\Commands\BuildBackpackCommand;
 use Backpack\Generators\Console\Commands\ButtonBackpackCommand;
 use Backpack\Generators\Console\Commands\ChartBackpackCommand;
 use Backpack\Generators\Console\Commands\ChartControllerBackpackCommand;
+use Backpack\Generators\Console\Commands\ColumnBackpackCommand;
 use Backpack\Generators\Console\Commands\ConfigBackpackCommand;
 use Backpack\Generators\Console\Commands\CrudBackpackCommand;
 use Backpack\Generators\Console\Commands\CrudControllerBackpackCommand;
@@ -25,6 +26,7 @@ class GeneratorsServiceProvider extends ServiceProvider
     protected $commands = [
         BuildBackpackCommand::class,
         ButtonBackpackCommand::class,
+        ColumnBackpackCommand::class,
         ConfigBackpackCommand::class,
         CrudModelBackpackCommand::class,
         CrudControllerBackpackCommand::class,


### PR DESCRIPTION
## WHY
It's Handy
### What is happening after this PR?
Genrate columns using command line.

## HOW
`php artisan backpack:column {name}`
`php artisan backpack:column {name} --from={column}`