### PR TITLE
Fixes on create/publish views commands

### DIFF
--- a/src/Console/Commands/ColumnBackpackCommand.php
+++ b/src/Console/Commands/ColumnBackpackCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 class ColumnBackpackCommand extends GeneratorCommand
 {
     use \Backpack\CRUD\app\Console\Commands\Traits\PrettyCommandOutput;
+
     /**
      * The console command name.
      *
@@ -38,6 +39,13 @@ class ColumnBackpackCommand extends GeneratorCommand
     protected $type = 'Column';
 
     /**
+     * View Namespace
+     *
+     * @var string
+     */
+    protected $viewNamespace = 'columns';
+
+    /**
      * Get the stub file for the generator.
      *
      * @return string
@@ -48,63 +56,60 @@ class ColumnBackpackCommand extends GeneratorCommand
     }
 
     /**
-     * Alias for the fire method.
-     *
-     * In Laravel 5.5 the fire() method has been renamed to handle().
-     * This alias provides support for both Laravel 5.4 and 5.5.
-     */
-    public function handle()
-    {
-        $this->fire();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return bool|null
      */
-    public function fire()
+    public function handle()
     {
         $name = Str::of($this->getNameInput());
-        $path = $this->getPath($name);
+        $path = Str::of($this->getPath($name));
+        $pathRelative = $path->after(base_path())->replace('\\', '/')->trim('/');
 
-        if ($this->alreadyExists($this->getNameInput())) {
-            $this->error("Error : $this->type $name already existed!");
+        $this->infoBlock("Creating {$name->replace('_', ' ')->title()} {$this->type}");
+        $this->progressBlock("Creating view <fg=blue>{$pathRelative}</>");
+
+        if ($this->alreadyExists($name)) {
+            $this->closeProgressBlock('Already existed', 'yellow');
 
             return false;
         }
 
-        $src = null;
+        $source = null;
         if ($this->option('from')) {
-            $column = Str::of($this->option('from'));
-            $arr = ViewNamespaces::getFor('columns');
-            foreach ($arr as $key => $value) {
-                $viewPath = $value.'.'.$column;
+            $from = $this->option('from');
+            $namespaces = ViewNamespaces::getFor($this->viewNamespace);
+            foreach ($namespaces as $namespace) {
+                $viewPath = "$namespace.$from";
                 if (view()->exists($viewPath)) {
-                    $src = view($viewPath)->getPath();
+                    $source = view($viewPath)->getPath();
                     break;
                 }
             }
-            if ($src == null) {
-                $this->error("Error : $this->type $column does not exist!");
+
+            // full file path may be provided
+            if (file_exists($from)) {
+                $source = $from;
+            }
+
+            if (! $source) {
+                $this->errorProgressBlock();
+                $this->note("$this->type '$from' does not exist!", 'red');
+                $this->newLine();
 
                 return false;
             }
         }
 
-        $this->infoBlock("Creating {$name->replace('_', ' ')->title()} {$this->type}");
-        $this->progressBlock("Creating view <fg=blue>resources/views/vendor/backpack/crud/columns/{$name->snake('_')}.blade.php</>");
-
         $this->makeDirectory($path);
-        if ($src != null) {
-            $this->files->copy($src, $path);
+
+        if ($source) {
+            $this->files->copy($source, $path);
         } else {
             $this->files->put($path, $this->buildClass($name));
         }
 
         $this->closeProgressBlock();
-        $this->newLine();
-        $this->info($this->type.' created successfully.');
     }
 
     /**
@@ -145,12 +150,15 @@ class ColumnBackpackCommand extends GeneratorCommand
     }
 
     /**
-     * Get the console command options.
+     * Get the desired class name from the input.
      *
-     * @return array
+     * @return string
      */
-    protected function getOptions()
+    protected function getNameInput()
     {
-        return [];
+        return Str::of($this->argument('name'))
+            ->trim()
+            ->snake('_')
+            ->value;
     }
 }

--- a/src/Console/Commands/FieldBackpackCommand.php
+++ b/src/Console/Commands/FieldBackpackCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 class FieldBackpackCommand extends GeneratorCommand
 {
     use \Backpack\CRUD\app\Console\Commands\Traits\PrettyCommandOutput;
+
     /**
      * The console command name.
      *
@@ -38,6 +39,13 @@ class FieldBackpackCommand extends GeneratorCommand
     protected $type = 'Field';
 
     /**
+     * View Namespace
+     *
+     * @var string
+     */
+    protected $viewNamespace = 'fields';
+
+    /**
      * Get the stub file for the generator.
      *
      * @return string
@@ -48,63 +56,60 @@ class FieldBackpackCommand extends GeneratorCommand
     }
 
     /**
-     * Alias for the fire method.
-     *
-     * In Laravel 5.5 the fire() method has been renamed to handle().
-     * This alias provides support for both Laravel 5.4 and 5.5.
-     */
-    public function handle()
-    {
-        $this->fire();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return bool|null
      */
-    public function fire()
+    public function handle()
     {
         $name = Str::of($this->getNameInput());
-        $path = $this->getPath($name);
+        $path = Str::of($this->getPath($name));
+        $pathRelative = $path->after(base_path())->replace('\\', '/')->trim('/');
 
-        if ($this->alreadyExists($this->getNameInput())) {
-            $this->error("Error : $this->type $name already existed!");
+        $this->infoBlock("Creating {$name->replace('_', ' ')->title()} {$this->type}");
+        $this->progressBlock("Creating view <fg=blue>{$pathRelative}</>");
+
+        if ($this->alreadyExists($name)) {
+            $this->closeProgressBlock('Already existed', 'yellow');
 
             return false;
         }
 
-        $src = null;
+        $source = null;
         if ($this->option('from')) {
-            $field = Str::of($this->option('from'));
-            $arr = ViewNamespaces::getFor('fields');
-            foreach ($arr as $key => $value) {
-                $viewPath = $value.'.'.$field;
+            $from = $this->option('from');
+            $namespaces = ViewNamespaces::getFor($this->viewNamespace);
+            foreach ($namespaces as $namespace) {
+                $viewPath = "$namespace.$from";
                 if (view()->exists($viewPath)) {
-                    $src = view($viewPath)->getPath();
+                    $source = view($viewPath)->getPath();
                     break;
                 }
             }
-            if ($src == null) {
-                $this->error("Error : $this->type $field does not exist!");
+
+            // full file path may be provided
+            if (file_exists($from)) {
+                $source = $from;
+            }
+
+            if (! $source) {
+                $this->errorProgressBlock();
+                $this->note("$this->type '$from' does not exist!", 'red');
+                $this->newLine();
 
                 return false;
             }
         }
 
-        $this->infoBlock("Creating {$name->replace('_', ' ')->title()} {$this->type}");
-        $this->progressBlock("Creating view <fg=blue>resources/views/vendor/backpack/crud/fields/{$name->snake('_')}.blade.php</>");
-
         $this->makeDirectory($path);
-        if ($src != null) {
-            $this->files->copy($src, $path);
+
+        if ($source) {
+            $this->files->copy($source, $path);
         } else {
             $this->files->put($path, $this->buildClass($name));
         }
 
         $this->closeProgressBlock();
-        $this->newLine();
-        $this->info($this->type.' created successfully.');
     }
 
     /**
@@ -134,7 +139,7 @@ class FieldBackpackCommand extends GeneratorCommand
     /**
      * Build the class with the given name.
      *
-     * @param  string  $name
+     * @param  Str $name
      * @return string
      */
     protected function buildClass($name)
@@ -148,12 +153,15 @@ class FieldBackpackCommand extends GeneratorCommand
     }
 
     /**
-     * Get the console command options.
+     * Get the desired class name from the input.
      *
-     * @return array
+     * @return string
      */
-    protected function getOptions()
+    protected function getNameInput()
     {
-        return [];
+        return Str::of($this->argument('name'))
+            ->trim()
+            ->snake('_')
+            ->value;
     }
 }

--- a/src/Console/Commands/FilterBackpackCommand.php
+++ b/src/Console/Commands/FilterBackpackCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 class FilterBackpackCommand extends GeneratorCommand
 {
     use \Backpack\CRUD\app\Console\Commands\Traits\PrettyCommandOutput;
+
     /**
      * The console command name.
      *
@@ -38,6 +39,13 @@ class FilterBackpackCommand extends GeneratorCommand
     protected $type = 'Filter';
 
     /**
+     * View Namespace
+     *
+     * @var string
+     */
+    protected $viewNamespace = 'filters';
+
+    /**
      * Get the stub file for the generator.
      *
      * @return string
@@ -48,63 +56,60 @@ class FilterBackpackCommand extends GeneratorCommand
     }
 
     /**
-     * Alias for the fire method.
-     *
-     * In Laravel 5.5 the fire() method has been renamed to handle().
-     * This alias provides support for both Laravel 5.4 and 5.5.
-     */
-    public function handle()
-    {
-        $this->fire();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return bool|null
      */
-    public function fire()
+    public function handle()
     {
         $name = Str::of($this->getNameInput());
-        $path = $this->getPath($name);
+        $path = Str::of($this->getPath($name));
+        $pathRelative = $path->after(base_path())->replace('\\', '/')->trim('/');
 
-        if ($this->alreadyExists($this->getNameInput())) {
-            $this->error("Error : $this->type $name already existed!");
+        $this->infoBlock("Creating {$name->replace('_', ' ')->title()} {$this->type}");
+        $this->progressBlock("Creating view <fg=blue>{$pathRelative}</>");
+
+        if ($this->alreadyExists($name)) {
+            $this->closeProgressBlock('Already existed', 'yellow');
 
             return false;
         }
 
-        $src = null;
+        $source = null;
         if ($this->option('from')) {
-            $filter = Str::of($this->option('from'));
-            $arr = ViewNamespaces::getFor('filters');
-            foreach ($arr as $key => $value) {
-                $viewPath = $value.'.'.$filter;
+            $from = $this->option('from');
+            $namespaces = ViewNamespaces::getFor($this->viewNamespace);
+            foreach ($namespaces as $namespace) {
+                $viewPath = "$namespace.$from";
                 if (view()->exists($viewPath)) {
-                    $src = view($viewPath)->getPath();
+                    $source = view($viewPath)->getPath();
                     break;
                 }
             }
-            if ($src == null) {
-                $this->error("Error : $this->type $filter does not exist!");
+
+            // full file path may be provided
+            if (file_exists($from)) {
+                $source = $from;
+            }
+
+            if (! $source) {
+                $this->errorProgressBlock();
+                $this->note("$this->type '$from' does not exist!", 'red');
+                $this->newLine();
 
                 return false;
             }
         }
 
-        $this->infoBlock("Creating {$name->replace('_', ' ')->title()} {$this->type}");
-        $this->progressBlock("Creating view <fg=blue>resources/views/vendor/backpack/crud/filters/{$name->snake('_')}.blade.php</>");
-
         $this->makeDirectory($path);
-        if ($src != null) {
-            $this->files->copy($src, $path);
+
+        if ($source) {
+            $this->files->copy($source, $path);
         } else {
             $this->files->put($path, $this->buildClass($name));
         }
 
         $this->closeProgressBlock();
-        $this->newLine();
-        $this->info($this->type.' created successfully.');
     }
 
     /**
@@ -145,12 +150,15 @@ class FilterBackpackCommand extends GeneratorCommand
     }
 
     /**
-     * Get the console command options.
+     * Get the desired class name from the input.
      *
-     * @return array
+     * @return string
      */
-    protected function getOptions()
+    protected function getNameInput()
     {
-        return [];
+        return Str::of($this->argument('name'))
+            ->trim()
+            ->snake('_')
+            ->value;
     }
 }

--- a/src/Console/Commands/WidgetBackpackCommand.php
+++ b/src/Console/Commands/WidgetBackpackCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 class WidgetBackpackCommand extends GeneratorCommand
 {
     use \Backpack\CRUD\app\Console\Commands\Traits\PrettyCommandOutput;
+
     /**
      * The console command name.
      *
@@ -38,6 +39,13 @@ class WidgetBackpackCommand extends GeneratorCommand
     protected $type = 'Widget';
 
     /**
+     * View Namespace
+     *
+     * @var string
+     */
+    protected $viewNamespace = 'widgets';
+
+    /**
      * Get the stub file for the generator.
      *
      * @return string
@@ -48,63 +56,60 @@ class WidgetBackpackCommand extends GeneratorCommand
     }
 
     /**
-     * Alias for the fire method.
-     *
-     * In Laravel 5.5 the fire() method has been renamed to handle().
-     * This alias provides support for both Laravel 5.4 and 5.5.
-     */
-    public function handle()
-    {
-        $this->fire();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return bool|null
      */
-    public function fire()
+    public function handle()
     {
         $name = Str::of($this->getNameInput());
-        $path = $this->getPath($name);
+        $path = Str::of($this->getPath($name));
+        $pathRelative = $path->after(base_path())->replace('\\', '/')->trim('/');
 
-        if ($this->alreadyExists($this->getNameInput())) {
-            $this->error("Error : $this->type $name already existed!");
+        $this->infoBlock("Creating {$name->replace('_', ' ')->title()} {$this->type}");
+        $this->progressBlock("Creating view <fg=blue>{$pathRelative}</>");
+
+        if ($this->alreadyExists($name)) {
+            $this->closeProgressBlock('Already existed', 'yellow');
 
             return false;
         }
 
-        $src = null;
+        $source = null;
         if ($this->option('from')) {
-            $widget = Str::of($this->option('from'));
-            $arr = ViewNamespaces::getFor('widgets');
-            foreach ($arr as $key => $value) {
-                $viewPath = $value.'.'.$widget;
+            $from = $this->option('from');
+            $namespaces = ViewNamespaces::getFor($this->viewNamespace);
+            foreach ($namespaces as $namespace) {
+                $viewPath = "$namespace.$from";
                 if (view()->exists($viewPath)) {
-                    $src = view($viewPath)->getPath();
+                    $source = view($viewPath)->getPath();
                     break;
                 }
             }
-            if ($src == null) {
-                $this->error("Error : $this->type $widget does not exist!");
+
+            // full file path may be provided
+            if (file_exists($from)) {
+                $source = $from;
+            }
+
+            if (! $source) {
+                $this->errorProgressBlock();
+                $this->note("$this->type '$from' does not exist!", 'red');
+                $this->newLine();
 
                 return false;
             }
         }
 
-        $this->infoBlock("Creating {$name->replace('_', ' ')->title()} {$this->type}");
-        $this->progressBlock("Creating view <fg=blue>resources/views/vendor/backpack/base/widgets/{$name->snake('_')}.blade.php</>");
-
         $this->makeDirectory($path);
-        if ($src != null) {
-            $this->files->copy($src, $path);
+
+        if ($source) {
+            $this->files->copy($source, $path);
         } else {
             $this->files->put($path, $this->buildClass($name));
         }
 
         $this->closeProgressBlock();
-        $this->newLine();
-        $this->info($this->type.' created successfully.');
     }
 
     /**
@@ -134,7 +139,7 @@ class WidgetBackpackCommand extends GeneratorCommand
     /**
      * Build the class with the given name.
      *
-     * @param  string  $name
+     * @param  Str  $name
      * @return string
      */
     protected function buildClass($name)
@@ -148,12 +153,15 @@ class WidgetBackpackCommand extends GeneratorCommand
     }
 
     /**
-     * Get the console command options.
+     * Get the desired class name from the input.
      *
-     * @return array
+     * @return string
      */
-    protected function getOptions()
+    protected function getNameInput()
     {
-        return [];
+        return Str::of($this->argument('name'))
+            ->trim()
+            ->snake('_')
+            ->value;
     }
 }

--- a/src/Console/stubs/field.stub
+++ b/src/Console/stubs/field.stub
@@ -22,7 +22,7 @@
 {{-- CUSTOM CSS --}}
 @push('crud_fields_styles')
     {{-- How to load a CSS file? --}}
-    @loadOnce(asset('dummyFieldStyle.css'))
+    @loadOnce('dummyFieldStyle.css')
 
     {{-- How to add some CSS? --}}
     @loadOnce('dummy_field_style')
@@ -37,10 +37,11 @@
 {{-- CUSTOM JS --}}
 @push('crud_fields_scripts')
     {{-- How to load a JS file? --}}
-    @loadOnce(asset('dummyFieldScript.js'))
+    @loadOnce('dummyFieldScript.js')
 
     {{-- How to add some JS to the field? --}}
     @loadOnce('bpFieldInitDummyFieldElement')
+    <script>
         function bpFieldInitDummyFieldElement(element) {
             // this function will be called on pageload, because it's
             // present as data-init-function in the HTML above; the
@@ -48,5 +49,6 @@
             // element where init function was defined
             console.log(element.val());
         }
+    </script>
     @endLoadOnce
 @endpush


### PR DESCRIPTION
This PR includes a bunch of fixes to;
- `src/Console/Commands/ButtonBackpackCommand.php`
- `src/Console/Commands/ColumnBackpackCommand.php`
- `src/Console/Commands/FieldBackpackCommand.php`
- `src/Console/Commands/FilterBackpackCommand.php`
- `src/Console/Commands/WidgetBackpackCommand.php`

Mostly opinionated, but some bug fixes too;
- Fixed order of messages on the console.
- `getNameInput` is now on all classes to make sure the name is always in the desired format.

This also aims to "standardize" these classes, in near future they may all be optimized by moving common methods to a trait.