### PR TITLE
Get the "name" from "--from" when it's not given

### DIFF
--- a/src/Console/Commands/ButtonBackpackCommand.php
+++ b/src/Console/Commands/ButtonBackpackCommand.php
@@ -22,7 +22,7 @@ class ButtonBackpackCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'backpack:button {name} {--from=}';
+    protected $signature = 'backpack:button {name?} {--from=}';
 
     /**
      * The console command description.
@@ -146,5 +146,27 @@ class ButtonBackpackCommand extends GeneratorCommand
         $stub = str_replace('dummy', $name, $stub);
 
         return $stub;
+    }
+
+    /**
+     * Get the desired class name from the input.
+     *
+     * @return string
+     */
+    protected function getNameInput()
+    {
+        $name = Str::of($this->argument('name'));
+        $from = Str::of($this->option('from'));
+
+        if ($name->isEmpty() && $from->isEmpty()) {
+            throw new \Exception('Not enough arguments (missing: "name" or "--from").');
+        }
+
+        // Name may come from the --from option
+        if ($name->isEmpty()) {
+            $name = $from->afterLast('/')->afterLast('\\');
+        }
+
+        return $name->trim()->snake('_')->value;
     }
 }

--- a/src/Console/Commands/ColumnBackpackCommand.php
+++ b/src/Console/Commands/ColumnBackpackCommand.php
@@ -22,7 +22,7 @@ class ColumnBackpackCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'backpack:column {name} {--from=}';
+    protected $signature = 'backpack:column {name?} {--from=}';
 
     /**
      * The console command description.
@@ -156,9 +156,18 @@ class ColumnBackpackCommand extends GeneratorCommand
      */
     protected function getNameInput()
     {
-        return Str::of($this->argument('name'))
-            ->trim()
-            ->snake('_')
-            ->value;
+        $name = Str::of($this->argument('name'));
+        $from = Str::of($this->option('from'));
+
+        if ($name->isEmpty() && $from->isEmpty()) {
+            throw new \Exception('Not enough arguments (missing: "name" or "--from").');
+        }
+
+        // Name may come from the --from option
+        if ($name->isEmpty()) {
+            $name = $from->afterLast('/')->afterLast('\\');
+        }
+
+        return $name->trim()->snake('_')->value;
     }
 }

--- a/src/Console/Commands/FieldBackpackCommand.php
+++ b/src/Console/Commands/FieldBackpackCommand.php
@@ -22,7 +22,7 @@ class FieldBackpackCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'backpack:field {name} {--from=}';
+    protected $signature = 'backpack:field {name?} {--from=}';
 
     /**
      * The console command description.
@@ -159,9 +159,18 @@ class FieldBackpackCommand extends GeneratorCommand
      */
     protected function getNameInput()
     {
-        return Str::of($this->argument('name'))
-            ->trim()
-            ->snake('_')
-            ->value;
+        $name = Str::of($this->argument('name'));
+        $from = Str::of($this->option('from'));
+
+        if ($name->isEmpty() && $from->isEmpty()) {
+            throw new \Exception('Not enough arguments (missing: "name" or "--from").');
+        }
+
+        // Name may come from the --from option
+        if ($name->isEmpty()) {
+            $name = $from->afterLast('/')->afterLast('\\');
+        }
+
+        return $name->trim()->snake('_')->value;
     }
 }

--- a/src/Console/Commands/FilterBackpackCommand.php
+++ b/src/Console/Commands/FilterBackpackCommand.php
@@ -22,7 +22,7 @@ class FilterBackpackCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'backpack:filter {name} {--from=}';
+    protected $signature = 'backpack:filter {name?} {--from=}';
 
     /**
      * The console command description.
@@ -156,9 +156,18 @@ class FilterBackpackCommand extends GeneratorCommand
      */
     protected function getNameInput()
     {
-        return Str::of($this->argument('name'))
-            ->trim()
-            ->snake('_')
-            ->value;
+        $name = Str::of($this->argument('name'));
+        $from = Str::of($this->option('from'));
+
+        if ($name->isEmpty() && $from->isEmpty()) {
+            throw new \Exception('Not enough arguments (missing: "name" or "--from").');
+        }
+
+        // Name may come from the --from option
+        if ($name->isEmpty()) {
+            $name = $from->afterLast('/')->afterLast('\\');
+        }
+
+        return $name->trim()->snake('_')->value;
     }
 }

--- a/src/Console/Commands/WidgetBackpackCommand.php
+++ b/src/Console/Commands/WidgetBackpackCommand.php
@@ -22,7 +22,7 @@ class WidgetBackpackCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'backpack:widget {name} {--from=}';
+    protected $signature = 'backpack:widget {name?} {--from=}';
 
     /**
      * The console command description.
@@ -159,9 +159,18 @@ class WidgetBackpackCommand extends GeneratorCommand
      */
     protected function getNameInput()
     {
-        return Str::of($this->argument('name'))
-            ->trim()
-            ->snake('_')
-            ->value;
+        $name = Str::of($this->argument('name'));
+        $from = Str::of($this->option('from'));
+
+        if ($name->isEmpty() && $from->isEmpty()) {
+            throw new \Exception('Not enough arguments (missing: "name" or "--from").');
+        }
+
+        // Name may come from the --from option
+        if ($name->isEmpty()) {
+            $name = $from->afterLast('/')->afterLast('\\');
+        }
+
+        return $name->trim()->snake('_')->value;
     }
 }


### PR DESCRIPTION
This allows to not pass the name when using `--from`.
When using from the name was being always required;

```zsh
php artisan backpack:filter bulk_clone --from bulk_clone
```

Now, if it is not given, it will get it from the `--from` option, allowing to simplify the command;

```zsh
php artisan backpack:filter --from bulk_clone
```