### PR TITLE
Allow absolute paths outside of app scope

### DIFF
--- a/src/Console/Commands/Views/PublishOrCreateViewBackpackCommand.php
+++ b/src/Console/Commands/Views/PublishOrCreateViewBackpackCommand.php
@@ -54,7 +54,7 @@ abstract class PublishOrCreateViewBackpackCommand extends GeneratorCommand
 
             // full or relative file path may be provided
             if (file_exists($from)) {
-                $source = Str::start($from, Str::finish(base_path(), '\\'));
+                $source = realpath($from);
             }
 
             if (! $source) {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

I use symlinks in my demo project, and I found that files outside of the project (demo) scope, were not being published, because they were being prefixed with the project `base_path()`.

### AFTER - What is happening after this PR?

By using PHP native [`realpath`](https://www.php.net/manual/en/function.realpath.php) method, all paths are now allowed 🙌
This will transform all paths in absolute paths, symlinks are properly resolved, it also resolves references `\..\` and extra slashes.

_**Note**: This still allows relative paths._

This should have been done this way the first time, my bad ✋

### Is it a breaking change or non-breaking change?

No.
