### PR TITLE
Fix for absolute paths in Unix file systems

### DIFF
--- a/src/Console/Commands/Views/PublishOrCreateViewBackpackCommand.php
+++ b/src/Console/Commands/Views/PublishOrCreateViewBackpackCommand.php
@@ -57,7 +57,7 @@ abstract class PublishOrCreateViewBackpackCommand extends GeneratorCommand
                 $source = realpath($from);
             }
             // remove the first slash to make absolute paths relative in unix systems
-            else if (file_exists(substr($from, 1))) {
+            elseif (file_exists(substr($from, 1))) {
                 $source = realpath(substr($from, 1));
             }
 

--- a/src/Console/Commands/Views/PublishOrCreateViewBackpackCommand.php
+++ b/src/Console/Commands/Views/PublishOrCreateViewBackpackCommand.php
@@ -56,6 +56,10 @@ abstract class PublishOrCreateViewBackpackCommand extends GeneratorCommand
             if (file_exists($from)) {
                 $source = realpath($from);
             }
+            // remove the first slash to make absolute paths relative in unix systems
+            else if (file_exists(substr($from, 1))) {
+                $source = realpath(substr($from, 1));
+            }
 
             if (! $source) {
                 $this->errorProgressBlock();


### PR DESCRIPTION
This should fix situations where a relative path is provided but it is interpreted as an absolute file path in unix like file systems because of the leading slash `/`.

`/path/to/something` is interpreted as relative to unix root, whereas it ~should~ **may**_(a)_ be a relative to the working dir `path/to/something`

This PR aims to make Generators support both, by looking for both.

---
_(a)_ Path can be both, either relative or absolute, that's why we can't just remove the slash `/`.