### PR TITLE
Override widget command path

### DIFF
--- a/src/Console/Commands/Views/WidgetBackpackCommand.php
+++ b/src/Console/Commands/Views/WidgetBackpackCommand.php
@@ -45,4 +45,15 @@ class WidgetBackpackCommand extends PublishOrCreateViewBackpackCommand
      * @var string
      */
     protected $stub = 'widget.stub';
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        return resource_path("views/vendor/backpack/base/{$this->viewNamespace}/$name.blade.php");
+    }
 }


### PR DESCRIPTION
Widget have a different path than the other views. This PR adds an override of the `getPath()` only to the widget command.