### PR TITLE
change default menu icon for generated CRUDs

### DIFF
--- a/src/Console/Commands/CrudBackpackCommand.php
+++ b/src/Console/Commands/CrudBackpackCommand.php
@@ -69,7 +69,7 @@ class CrudBackpackCommand extends GeneratorCommand
 
         // Create the sidebar item
         $this->call('backpack:add-sidebar-content', [
-            'code' => "<li class=\"nav-item\"><a class=\"nav-link\" href=\"{{ backpack_url('$nameKebab') }}\"><i class=\"nav-icon la la-question\"></i> $namePlural</a></li>",
+            'code' => "<li class=\"nav-item\"><a class=\"nav-link\" href=\"{{ backpack_url('$nameKebab') }}\"><i class=\"nav-icon la la-th-list\"></i> $namePlural</a></li>",
         ]);
 
         // if the application uses cached routes, we should rebuild the cache so the previous added route will


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

When you generated a CRUD, the default icon was a question mark, to force devs into choosing their own. When you generated a Page, the default icon was STILL a question mark... so... you couldn't really differentiate between what you've created.

### AFTER - What is happening after this PR?

When a new CRUD is created, the default icon is a table, instead of a question mark:

![CleanShot 2022-12-16 at 10 44 12](https://user-images.githubusercontent.com/1032474/208059111-ea7c535d-5a57-456d-886e-2775fffeea7e.png)

---

Anyone please double-check, so I can merge?