### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/Console/Commands/PageBackpackCommand.php
+++ b/src/Console/Commands/PageBackpackCommand.php
@@ -70,7 +70,7 @@ class PageBackpackCommand extends GeneratorCommand
 
         $this->infoBlock("Creating {$nameTitle} page");
 
-        $this->progressBlock("Creating view <fg=blue>resources/views/${filePath}.blade.php</>");
+        $this->progressBlock("Creating view <fg=blue>resources/views/{$filePath}.blade.php</>");
 
         // check if the file already exists
         if ((! $this->hasOption('force') || ! $this->option('force')) && $this->alreadyExists($filePath)) {


### PR DESCRIPTION
Fixes #178

## WHY

### BEFORE - What was wrong? What was happening before this PR?

Deprecation warning, see #178

### AFTER - What is happening after this PR?

No deprecation warning


## HOW

### How did you achieve that, in technical terms?

Used `{$filePath}` instead of `${filePath}`



### Is it a breaking change or non-breaking change?

Non-breaking


### How can we test the before & after?

Test it in PHP 8.2
