### PR TITLE
Fix deprecation warning message

### DIFF
--- a/src/Console/Commands/PageBackpackCommand.php
+++ b/src/Console/Commands/PageBackpackCommand.php
@@ -70,7 +70,7 @@ class PageBackpackCommand extends GeneratorCommand
 
         $this->infoBlock("Creating {$nameTitle} page");
 
-        $this->progressBlock("Creating view <fg=blue>resources/views/${filePath}.blade.php</>");
+        $this->progressBlock("Creating view <fg=blue>resources/views/{$filePath}.blade.php</>");
 
         // check if the file already exists
         if ((! $this->hasOption('force') || ! $this->option('force')) && $this->alreadyExists($filePath)) {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We were getting a deprecation warning message:
`PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /app/vendor/backpack/generators/src/Console/Commands/PageBackpackCommand.php on line 73`

### AFTER - What is happening after this PR?

Stop getting the warning message.


## HOW

### How did you achieve that, in technical terms?

N/A



### Is it a breaking change or non-breaking change?

Non-breaking


### How can we test the before & after?

N/A
