### PR TITLE
fix add crudtrait to crud

### DIFF
--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -106,19 +106,22 @@ class CrudModelBackpackCommand extends BackpackCommand
 
             // check if it already uses CrudTrait
             // if it does, do nothing
-            if (Str::contains($content, $this->crudTrait)) {
+            if ($content->contains($this->crudTrait)) {
                 $this->closeProgressBlock('Already existed', 'yellow');
 
                 return false;
             } else {
-                $modifiedContent = Str::of(Str::before($content, ';'))
+                $modifiedContent = Str::of($content->before(';'))
                                         ->append(';'.PHP_EOL.PHP_EOL.'use Backpack\CRUD\app\Models\Traits\CrudTrait;');
 
                 $content = $content->after(';');
 
-                $hasNewLine = str_starts_with($content, '\n') ? 1 : 0;
+                $hasNewLine = str_starts_with($content, '\n\n') ? 1 : 0;
 
                 $modifiedContent = $modifiedContent->append(substr($content, strpos($content, "\n") + $hasNewLine));
+
+                // use the CrudTrait on the class
+                $modifiedContent = $modifiedContent->replaceFirst('{', '{'.PHP_EOL.'    use CrudTrait;');
 
                 // save the file
                 $this->files->put($path, $modifiedContent);

--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -115,11 +115,13 @@ class CrudModelBackpackCommand extends BackpackCommand
                                         ->append(';'.PHP_EOL.PHP_EOL.'use Backpack\CRUD\app\Models\Traits\CrudTrait;');
 
                 $content = $content->after(';');
-
-                $hasNewLine = str_starts_with($content, '\n\n') ? 1 : 0;
-
-                $modifiedContent = $modifiedContent->append(substr($content, strpos($content, "\n") + $hasNewLine));
-
+               
+                while(str_starts_with($content, PHP_EOL) || str_starts_with($content, "\n")) {
+                    $content = substr($content, 1);
+                }
+            
+                $modifiedContent = $modifiedContent->append(PHP_EOL.$content);
+                
                 // use the CrudTrait on the class
                 $modifiedContent = $modifiedContent->replaceFirst('{', '{'.PHP_EOL.'    use CrudTrait;');
 

--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -3,6 +3,7 @@
 namespace Backpack\Generators\Console\Commands;
 
 use Backpack\Generators\Services\BackpackCommand;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 
 class CrudModelBackpackCommand extends BackpackCommand
@@ -101,45 +102,31 @@ class CrudModelBackpackCommand extends BackpackCommand
         if (! $this->hasOption('force') || ! $this->option('force')) {
             $this->progressBlock('Adding CrudTrait to the Model');
 
-            $file = $this->files->get($path);
-            $lines = preg_split('/(\r\n)|\r|\n/', $file);
+            $content = Str::of($this->files->get($path));
 
             // check if it already uses CrudTrait
             // if it does, do nothing
-            if (Str::contains($file, $this->crudTrait)) {
+            if (Str::contains($content, $this->crudTrait)) {
                 $this->closeProgressBlock('Already existed', 'yellow');
 
                 return false;
+            } else {
+                $modifiedContent = Str::of(Str::before($content, ';'))
+                                        ->append(';'.PHP_EOL.PHP_EOL.'use Backpack\CRUD\app\Models\Traits\CrudTrait;');
+
+                $content = $content->after(';');
+
+                $hasNewLine = str_starts_with($content, '\n') ? 1 : 0;
+
+                $modifiedContent = $modifiedContent->append(substr($content, strpos($content, "\n") + $hasNewLine));
+
+                // save the file
+                $this->files->put($path, $modifiedContent);
+                // let the user know what we've done
+                $this->closeProgressBlock();
+
+                return true;
             }
-
-            // if it does not have CrudTrait, add the trait on the Model
-            foreach ($lines as $key => $line) {
-                if (Str::contains($line, "class {$name} extends")) {
-                    if (Str::endsWith($line, '{')) {
-                        // add the trait on the next
-                        $position = $key + 1;
-                    } elseif ($lines[$key + 1] == '{') {
-                        // add the trait on the next next line
-                        $position = $key + 2;
-                    }
-
-                    // keep in mind that the line number shown in IDEs is not
-                    // the same as the array index - arrays start counting from 0,
-                    // IDEs start counting from 1
-
-                    // add CrudTrait
-                    array_splice($lines, $position, 0, "    use \\{$this->crudTrait};");
-
-                    // save the file
-                    $this->files->put($path, implode(PHP_EOL, $lines));
-
-                    // let the user know what we've done
-                    $this->closeProgressBlock();
-
-                    return false;
-                }
-            }
-
             // In case we couldn't add the CrudTrait
             $this->errorProgressBlock();
             $this->note("Model already existed on '$name' and we couldn't add CrudTrait. Please add it manually.", 'red');

--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -115,13 +115,13 @@ class CrudModelBackpackCommand extends BackpackCommand
                                         ->append(';'.PHP_EOL.PHP_EOL.'use Backpack\CRUD\app\Models\Traits\CrudTrait;');
 
                 $content = $content->after(';');
-               
-                while(str_starts_with($content, PHP_EOL) || str_starts_with($content, "\n")) {
+
+                while (str_starts_with($content, PHP_EOL) || str_starts_with($content, "\n")) {
                     $content = substr($content, 1);
                 }
-            
+
                 $modifiedContent = $modifiedContent->append(PHP_EOL.$content);
-                
+
                 // use the CrudTrait on the class
                 $modifiedContent = $modifiedContent->replaceFirst('{', '{'.PHP_EOL.'    use CrudTrait;');
 


### PR DESCRIPTION
fixes #181 

This is the same script snippet used in devtools `Add Crud Trait` button. 

We should probably extract this bit of code to some place where it could be re-used by both devtools button and generators command. 

For now they have the same code 👍 

