### PR TITLE
Use class namespace when adding CrudTrait to model

### DIFF
--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -116,13 +116,13 @@ class CrudModelBackpackCommand extends BackpackCommand
                                     ->append(';'.PHP_EOL.PHP_EOL.'use Backpack\CRUD\app\Models\Traits\CrudTrait;');
 
                 $content = $content->after('namespace')->after(';');
-               
-                while(str_starts_with($content, PHP_EOL) || str_starts_with($content, "\n")) {
+
+                while (str_starts_with($content, PHP_EOL) || str_starts_with($content, "\n")) {
                     $content = substr($content, 1);
                 }
-            
+
                 $modifiedContent = $modifiedContent->append(PHP_EOL.$content);
-                
+
                 // use the CrudTrait on the class
                 $modifiedContent = $modifiedContent->replaceFirst('{', '{'.PHP_EOL.'    use CrudTrait;');
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Last fix I did relied on the first class `;`. 
That would broke in case developer used `declare(strict_types=1);` at the top of the file.

### AFTER - What is happening after this PR?

It does not break anymore.


## HOW

### How did you achieve that, in technical terms?

Use the `namespace` definition as the placeholder to add the crud trait.

### Is it a breaking change or non-breaking change?

No