### PR TITLE
Fix: `build` command triggered an error on Laravel 8

### DIFF
--- a/src/Console/Commands/BuildBackpackCommand.php
+++ b/src/Console/Commands/BuildBackpackCommand.php
@@ -68,7 +68,7 @@ class BuildBackpackCommand extends Command
             }
 
             // Try to load it by path as namespace
-            $class = (string)Str::of($filepath)
+            $class = (string) Str::of($filepath)
                 ->after(base_path())
                 ->trim('\\/')
                 ->replace('/', '\\')

--- a/src/Console/Commands/BuildBackpackCommand.php
+++ b/src/Console/Commands/BuildBackpackCommand.php
@@ -68,13 +68,12 @@ class BuildBackpackCommand extends Command
             }
 
             // Try to load it by path as namespace
-            $class = Str::of($filepath)
+            $class = (string)Str::of($filepath)
                 ->after(base_path())
                 ->trim('\\/')
                 ->replace('/', '\\')
                 ->before('.php')
-                ->ucfirst()
-                ->value();
+                ->ucfirst();
 
             $result = $this->validateModelClass($class);
             if ($result) {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

This StackOverflow post - https://stackoverflow.com/questions/75451809/artisan-backpackbuild-fails-with-badmethodcallexception - shows we have a bug in the current Generators + L8.

That's because `Stringable::value()` [was added in Laravel 9](https://github.com/laravel/framework/commit/d7cf744ca1601c27410dd6b8b4d1cb7389bd3039), not L8. 

### AFTER - What is happening after this PR?

We're still using the string, but without the method.


## HOW

### How did you achieve that, in technical terms?

The old switcheroo.



### Is it a breaking change or non-breaking change?

Non-breaking.


### How can we test the before & after?

Run `php artisan backpack:build` with the setup defined here  - https://stackoverflow.com/questions/75451809/artisan-backpackbuild-fails-with-badmethodcallexception
