### PR TITLE
fix publish widget path

### DIFF
--- a/src/Console/Commands/Views/WidgetBackpackCommand.php
+++ b/src/Console/Commands/Views/WidgetBackpackCommand.php
@@ -54,6 +54,8 @@ class WidgetBackpackCommand extends PublishOrCreateViewBackpackCommand
      */
     protected function getPath($name)
     {
-        return resource_path("views/vendor/backpack/base/{$this->viewNamespace}/$name.blade.php");
+        $path = 'views/vendor/backpack/ui/'.$this->viewNamespace.'/'.$name.'.blade.php';
+
+        return resource_path($path);
     }
 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Widgets were published to old `/base/` path. 

### AFTER - What is happening after this PR?

They are now published to the new `ui` folder.


@tabacitu there is still an issue that I am trying to come up with a solution. 

The current publish script is not "theme aware", it was previously only a 1-1 (vendor - user) relation. 

At the moment, if you do for example: `backpack:widget myCard --from=card`, since tabler overwrites the `card` widget it will correctly pick the file from the theme to publish. 
The problem is now where to publish this file in user land. 

If the theme does not overwrite the widget, it will publish the widget from the core ui ... to the ui (in userland) 🟢 
If the theme overwrites the widget, it will correctly pick the widget from theme🟢 but publish it to the ui (in userland) 🔴 

I am working on a solution for this.