### PR TITLE
When generating cruds use blade components for menu items

### DIFF
--- a/src/Console/Commands/CrudBackpackCommand.php
+++ b/src/Console/Commands/CrudBackpackCommand.php
@@ -69,7 +69,7 @@ class CrudBackpackCommand extends BackpackCommand
 
         // Create the menu item
         $this->call('backpack:add-menu-content', [
-            'code' => "<x-backpack::menu-item title=\"". $fullNameWithSpaces ."\" icon=\"la la-question\" :link=\"backpack_url('".$nameKebab."')\" />",
+            'code' => '<x-backpack::menu-item title="'.$fullNameWithSpaces."\" icon=\"la la-question\" :link=\"backpack_url('".$nameKebab."')\" />",
         ]);
 
         // if the application uses cached routes, we should rebuild the cache so the previous added route will

--- a/src/Console/Commands/CrudBackpackCommand.php
+++ b/src/Console/Commands/CrudBackpackCommand.php
@@ -69,7 +69,7 @@ class CrudBackpackCommand extends BackpackCommand
 
         // Create the menu item
         $this->call('backpack:add-menu-content', [
-            'code' => "<li class=\"nav-item\"><a class=\"nav-link\" href=\"{{ backpack_url('$nameKebab') }}\"><i class=\"nav-icon la la-question\"></i> $fullNameWithSpaces</a></li>",
+            'code' => "<x-backpack::menu-item title=\"". $fullNameWithSpaces ."\" icon=\"la la-question\" :link=\"backpack_url('".$nameKebab."')\" />",
         ]);
 
         // if the application uses cached routes, we should rebuild the cache so the previous added route will

--- a/src/Console/Commands/PageBackpackCommand.php
+++ b/src/Console/Commands/PageBackpackCommand.php
@@ -102,7 +102,7 @@ class PageBackpackCommand extends GeneratorCommand
 
         // create the menu item
         $this->call('backpack:add-menu-content', [
-            'code' => "<li class=\"nav-item\"><a class=\"nav-link\" href=\"{{ backpack_url('{$route}') }}\"><i class=\"nav-icon la la-question\"></i> {$nameTitle}</a></li>",
+            'code' => "<x-backpack::menu-item title=\"" . $nameTitle . "\" icon=\"la la-question\" :link=\"backpack_url('" . $route . "')\" />",
         ]);
 
         $url = backpack_url($route);

--- a/src/Console/Commands/PageBackpackCommand.php
+++ b/src/Console/Commands/PageBackpackCommand.php
@@ -102,7 +102,7 @@ class PageBackpackCommand extends GeneratorCommand
 
         // create the menu item
         $this->call('backpack:add-menu-content', [
-            'code' => "<x-backpack::menu-item title=\"" . $nameTitle . "\" icon=\"la la-question\" :link=\"backpack_url('" . $route . "')\" />",
+            'code' => '<x-backpack::menu-item title="'.$nameTitle."\" icon=\"la la-question\" :link=\"backpack_url('".$route."')\" />",
         ]);
 
         $url = backpack_url($route);


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We were generating simple HTML for menu items, even though we added blade components for them in https://github.com/Laravel-Backpack/CRUD/pull/5135/

### AFTER - What is happening after this PR?

We generate menu items using the Blade components.
