### PR TITLE
Pr/188 - allow stub publish

### DIFF
--- a/src/Console/Commands/ChartControllerBackpackCommand.php
+++ b/src/Console/Commands/ChartControllerBackpackCommand.php
@@ -55,6 +55,11 @@ class ChartControllerBackpackCommand extends GeneratorCommand
      */
     protected function getStub()
     {
+        // check if base_path('stubs/backpack/generators/chart-controller.stub') exists, and use that
+        if (file_exists(base_path('stubs/backpack/generators/chart-controller.stub'))) {
+            return base_path('stubs/backpack/generators/chart-controller.stub');
+        }
+
         return __DIR__.'/../stubs/chart-controller.stub';
     }
 

--- a/src/Console/Commands/ChartControllerBackpackCommand.php
+++ b/src/Console/Commands/ChartControllerBackpackCommand.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Str;
 
 class ChartControllerBackpackCommand extends GeneratorCommand
 {
+    use \Backpack\Generators\Console\Commands\Traits\PublishableStubTrait;
+
     /**
      * The console command name.
      *
@@ -55,12 +57,7 @@ class ChartControllerBackpackCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        // check if base_path('stubs/backpack/generators/chart-controller.stub') exists, and use that
-        if (file_exists(base_path('stubs/backpack/generators/chart-controller.stub'))) {
-            return base_path('stubs/backpack/generators/chart-controller.stub');
-        }
-
-        return __DIR__.'/../stubs/chart-controller.stub';
+        return $this->getStubPath('chart-controller');
     }
 
     /**

--- a/src/Console/Commands/ConfigBackpackCommand.php
+++ b/src/Console/Commands/ConfigBackpackCommand.php
@@ -41,6 +41,11 @@ class ConfigBackpackCommand extends GeneratorCommand
      */
     protected function getStub()
     {
+        // check if base_path('stubs/backpack/generators/config.stub') exists, and use that
+        if (file_exists(base_path('stubs/backpack/generators/config.stub'))) {
+            return base_path('stubs/backpack/generators/config.stub');
+        }
+
         return __DIR__.'/../stubs/config.stub';
     }
 

--- a/src/Console/Commands/ConfigBackpackCommand.php
+++ b/src/Console/Commands/ConfigBackpackCommand.php
@@ -6,6 +6,8 @@ use Illuminate\Console\GeneratorCommand;
 
 class ConfigBackpackCommand extends GeneratorCommand
 {
+    use \Backpack\Generators\Console\Commands\Traits\PublishableStubTrait;
+
     /**
      * The console command name.
      *
@@ -41,12 +43,7 @@ class ConfigBackpackCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        // check if base_path('stubs/backpack/generators/config.stub') exists, and use that
-        if (file_exists(base_path('stubs/backpack/generators/config.stub'))) {
-            return base_path('stubs/backpack/generators/config.stub');
-        }
-
-        return __DIR__.'/../stubs/config.stub';
+        return $this->getStubPath('config');
     }
 
     /**

--- a/src/Console/Commands/CrudControllerBackpackCommand.php
+++ b/src/Console/Commands/CrudControllerBackpackCommand.php
@@ -94,6 +94,11 @@ class CrudControllerBackpackCommand extends BackpackCommand
      */
     protected function getStub()
     {
+        // check if base_path('stubs/backpack/generators/crud-controller.stub') exists, and use that
+        if (file_exists(base_path('stubs/backpack/generators/crud-controller.stub'))) {
+            return base_path('stubs/backpack/generators/crud-controller.stub');
+        }
+
         return __DIR__.'/../stubs/crud-controller.stub';
     }
 

--- a/src/Console/Commands/CrudControllerBackpackCommand.php
+++ b/src/Console/Commands/CrudControllerBackpackCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 class CrudControllerBackpackCommand extends BackpackCommand
 {
     use \Backpack\CRUD\app\Console\Commands\Traits\PrettyCommandOutput;
+    use \Backpack\Generators\Console\Commands\Traits\PublishableStubTrait;
 
     /**
      * The console command name.
@@ -94,12 +95,7 @@ class CrudControllerBackpackCommand extends BackpackCommand
      */
     protected function getStub()
     {
-        // check if base_path('stubs/backpack/generators/crud-controller.stub') exists, and use that
-        if (file_exists(base_path('stubs/backpack/generators/crud-controller.stub'))) {
-            return base_path('stubs/backpack/generators/crud-controller.stub');
-        }
-
-        return __DIR__.'/../stubs/crud-controller.stub';
+        return $this->getStubPath('crud-controller');
     }
 
     /**

--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -146,6 +146,11 @@ class CrudModelBackpackCommand extends BackpackCommand
      */
     protected function getStub()
     {
+        // check if base_path('stubs/backpack/generators/crud-model.stub') exists, and use that
+        if (file_exists(base_path('stubs/backpack/generators/crud-model.stub'))) {
+            return base_path('stubs/backpack/generators/crud-model.stub');
+        }
+
         return __DIR__.'/../stubs/crud-model.stub';
     }
 

--- a/src/Console/Commands/CrudModelBackpackCommand.php
+++ b/src/Console/Commands/CrudModelBackpackCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 class CrudModelBackpackCommand extends BackpackCommand
 {
     use \Backpack\CRUD\app\Console\Commands\Traits\PrettyCommandOutput;
+    use \Backpack\Generators\Console\Commands\Traits\PublishableStubTrait;
 
     /**
      * The console command name.
@@ -146,12 +147,7 @@ class CrudModelBackpackCommand extends BackpackCommand
      */
     protected function getStub()
     {
-        // check if base_path('stubs/backpack/generators/crud-model.stub') exists, and use that
-        if (file_exists(base_path('stubs/backpack/generators/crud-model.stub'))) {
-            return base_path('stubs/backpack/generators/crud-model.stub');
-        }
-
-        return __DIR__.'/../stubs/crud-model.stub';
+        return $this->getStubPath('crud-model');
     }
 
     /**

--- a/src/Console/Commands/CrudOperationBackpackCommand.php
+++ b/src/Console/Commands/CrudOperationBackpackCommand.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Str;
 
 class CrudOperationBackpackCommand extends GeneratorCommand
 {
+    use \Backpack\Generators\Console\Commands\Traits\PublishableStubTrait;
+
     /**
      * The console command name.
      *
@@ -55,12 +57,7 @@ class CrudOperationBackpackCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        // check if base_path('stubs/backpack/generators/crud-operation.stub') exists, and use that
-        if (file_exists(base_path('stubs/backpack/generators/crud-operation.stub'))) {
-            return base_path('stubs/backpack/generators/crud-operation.stub');
-        }
-
-        return __DIR__.'/../stubs/crud-operation.stub';
+        return $this->getStubPath('crud-operation');
     }
 
     /**

--- a/src/Console/Commands/CrudOperationBackpackCommand.php
+++ b/src/Console/Commands/CrudOperationBackpackCommand.php
@@ -55,6 +55,11 @@ class CrudOperationBackpackCommand extends GeneratorCommand
      */
     protected function getStub()
     {
+        // check if base_path('stubs/backpack/generators/crud-operation.stub') exists, and use that
+        if (file_exists(base_path('stubs/backpack/generators/crud-operation.stub'))) {
+            return base_path('stubs/backpack/generators/crud-operation.stub');
+        }
+
         return __DIR__.'/../stubs/crud-operation.stub';
     }
 

--- a/src/Console/Commands/CrudRequestBackpackCommand.php
+++ b/src/Console/Commands/CrudRequestBackpackCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 class CrudRequestBackpackCommand extends BackpackCommand
 {
     use \Backpack\CRUD\app\Console\Commands\Traits\PrettyCommandOutput;
+    use \Backpack\Generators\Console\Commands\Traits\PublishableStubTrait;
 
     /**
      * The console command name.
@@ -93,12 +94,7 @@ class CrudRequestBackpackCommand extends BackpackCommand
      */
     protected function getStub()
     {
-        // check if base_path('stubs/backpack/generators/crud-request.stub') exists, and use that
-        if (file_exists(base_path('stubs/backpack/generators/crud-request.stub'))) {
-            return base_path('stubs/backpack/generators/crud-request.stub');
-        }
-
-        return __DIR__.'/../stubs/crud-request.stub';
+        return $this->getStubPath('crud-request');
     }
 
     /**

--- a/src/Console/Commands/CrudRequestBackpackCommand.php
+++ b/src/Console/Commands/CrudRequestBackpackCommand.php
@@ -93,6 +93,11 @@ class CrudRequestBackpackCommand extends BackpackCommand
      */
     protected function getStub()
     {
+        // check if base_path('stubs/backpack/generators/crud-request.stub') exists, and use that
+        if (file_exists(base_path('stubs/backpack/generators/crud-request.stub'))) {
+            return base_path('stubs/backpack/generators/crud-request.stub');
+        }
+
         return __DIR__.'/../stubs/crud-request.stub';
     }
 

--- a/src/Console/Commands/ModelBackpackCommand.php
+++ b/src/Console/Commands/ModelBackpackCommand.php
@@ -44,7 +44,6 @@ class ModelBackpackCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-
         if ($this->option('softdelete')) {
             return $this->getStubPath('model-softdelete');
         }

--- a/src/Console/Commands/ModelBackpackCommand.php
+++ b/src/Console/Commands/ModelBackpackCommand.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Str;
 
 class ModelBackpackCommand extends GeneratorCommand
 {
+    use \Backpack\Generators\Console\Commands\Traits\PublishableStubTrait;
+
     /**
      * The console command name.
      *
@@ -42,21 +44,12 @@ class ModelBackpackCommand extends GeneratorCommand
      */
     protected function getStub()
     {
+
         if ($this->option('softdelete')) {
-            // check if base_path('stubs/backpack/generators/model-softdelete.stub') exists, and use that
-            if (file_exists(base_path('stubs/backpack/generators/model-softdelete.stub'))) {
-                return base_path('stubs/backpack/generators/model-softdelete.stub');
-            }
-
-            return __DIR__.'/../stubs/model-softdelete.stub';
+            return $this->getStubPath('model-softdelete');
         }
 
-        // check if base_path('stubs/backpack/generators/model.stub') exists, and use that
-        if (file_exists(base_path('stubs/backpack/generators/model.stub'))) {
-            return base_path('stubs/backpack/generators/model.stub');
-        }
-
-        return __DIR__.'/../stubs/model.stub';
+        return $this->getStubPath('model');
     }
 
     /**

--- a/src/Console/Commands/ModelBackpackCommand.php
+++ b/src/Console/Commands/ModelBackpackCommand.php
@@ -43,7 +43,17 @@ class ModelBackpackCommand extends GeneratorCommand
     protected function getStub()
     {
         if ($this->option('softdelete')) {
+            // check if base_path('stubs/backpack/generators/model-softdelete.stub') exists, and use that
+            if (file_exists(base_path('stubs/backpack/generators/model-softdelete.stub'))) {
+                return base_path('stubs/backpack/generators/model-softdelete.stub');
+            }
+
             return __DIR__.'/../stubs/model-softdelete.stub';
+        }
+
+        // check if base_path('stubs/backpack/generators/model.stub') exists, and use that
+        if (file_exists(base_path('stubs/backpack/generators/model.stub'))) {
+            return base_path('stubs/backpack/generators/model.stub');
         }
 
         return __DIR__.'/../stubs/model.stub';

--- a/src/Console/Commands/PageBackpackCommand.php
+++ b/src/Console/Commands/PageBackpackCommand.php
@@ -120,6 +120,11 @@ class PageBackpackCommand extends GeneratorCommand
      */
     protected function getStub()
     {
+        // check if base_path('stubs/backpack/generators/page.stub') exists, and use that
+        if (file_exists(base_path('stubs/backpack/generators/page.stub'))) {
+            return base_path('stubs/backpack/generators/page.stub');
+        }
+
         return __DIR__.'/../stubs/page.stub';
     }
 

--- a/src/Console/Commands/PageBackpackCommand.php
+++ b/src/Console/Commands/PageBackpackCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 class PageBackpackCommand extends GeneratorCommand
 {
     use \Backpack\CRUD\app\Console\Commands\Traits\PrettyCommandOutput;
+    use \Backpack\Generators\Console\Commands\Traits\PublishableStubTrait;
 
     /**
      * The console command name.
@@ -120,12 +121,7 @@ class PageBackpackCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        // check if base_path('stubs/backpack/generators/page.stub') exists, and use that
-        if (file_exists(base_path('stubs/backpack/generators/page.stub'))) {
-            return base_path('stubs/backpack/generators/page.stub');
-        }
-
-        return __DIR__.'/../stubs/page.stub';
+        return $this->getStubPath('page');
     }
 
     /**

--- a/src/Console/Commands/PageControllerBackpackCommand.php
+++ b/src/Console/Commands/PageControllerBackpackCommand.php
@@ -111,6 +111,11 @@ class PageControllerBackpackCommand extends GeneratorCommand
      */
     protected function getStub()
     {
+        // check if base_path('stubs/backpack/generators/page-controller.stub') exists, and use that
+        if (file_exists(base_path('stubs/backpack/generators/page-controller.stub'))) {
+            return base_path('stubs/backpack/generators/page-controller.stub');
+        }
+
         return __DIR__.'/../stubs/page-controller.stub';
     }
 

--- a/src/Console/Commands/PageControllerBackpackCommand.php
+++ b/src/Console/Commands/PageControllerBackpackCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Stringable;
 class PageControllerBackpackCommand extends GeneratorCommand
 {
     use \Backpack\CRUD\app\Console\Commands\Traits\PrettyCommandOutput;
+    use \Backpack\Generators\Console\Commands\Traits\PublishableStubTrait;
 
     /**
      * The console command name.
@@ -111,12 +112,7 @@ class PageControllerBackpackCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        // check if base_path('stubs/backpack/generators/page-controller.stub') exists, and use that
-        if (file_exists(base_path('stubs/backpack/generators/page-controller.stub'))) {
-            return base_path('stubs/backpack/generators/page-controller.stub');
-        }
-
-        return __DIR__.'/../stubs/page-controller.stub';
+        return $this->getStubPath('page-controller');
     }
 
     /**

--- a/src/Console/Commands/RequestBackpackCommand.php
+++ b/src/Console/Commands/RequestBackpackCommand.php
@@ -6,6 +6,8 @@ use Illuminate\Console\GeneratorCommand;
 
 class RequestBackpackCommand extends GeneratorCommand
 {
+    use \Backpack\Generators\Console\Commands\Traits\PublishableStubTrait;
+
     /**
      * The console command name.
      *
@@ -41,12 +43,7 @@ class RequestBackpackCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        // check if base_path('stubs/backpack/generators/request.stub') exists, and use that
-        if (file_exists(base_path('stubs/backpack/generators/request.stub'))) {
-            return base_path('stubs/backpack/generators/request.stub');
-        }
-
-        return __DIR__.'/../stubs/request.stub';
+        return $this->getStubPath('request');
     }
 
     /**

--- a/src/Console/Commands/RequestBackpackCommand.php
+++ b/src/Console/Commands/RequestBackpackCommand.php
@@ -41,6 +41,11 @@ class RequestBackpackCommand extends GeneratorCommand
      */
     protected function getStub()
     {
+        // check if base_path('stubs/backpack/generators/request.stub') exists, and use that
+        if (file_exists(base_path('stubs/backpack/generators/request.stub'))) {
+            return base_path('stubs/backpack/generators/request.stub');
+        }
+
         return __DIR__.'/../stubs/request.stub';
     }
 

--- a/src/Console/Commands/Traits/PublishableStubTrait.php
+++ b/src/Console/Commands/Traits/PublishableStubTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Backpack\Generators\Console\Commands\Traits;
+
+trait PublishableStubTrait
+{
+    /**
+     * Check if the stub exists in the project's stubs folder.
+     * If it does, return the path to it.
+     * If it doesn't, return the path to the stub in the package.
+     *
+     * @param  string  $path
+     *
+     * @return string
+     */
+    public function getStubPath(string $path): string
+    {
+        if (file_exists(base_path('stubs/backpack/generators/{$stub}.stub'))) {
+            return base_path('stubs/backpack/generators/{$stub}.stub');
+        }
+
+        return __DIR__.'/../stubs/{$stub}.stub';
+    }
+}

--- a/src/Console/Commands/Traits/PublishableStubTrait.php
+++ b/src/Console/Commands/Traits/PublishableStubTrait.php
@@ -10,7 +10,6 @@ trait PublishableStubTrait
      * If it doesn't, return the path to the stub in the package.
      *
      * @param  string  $path
-     *
      * @return string
      */
     public function getStubPath(string $path): string

--- a/src/Console/Commands/Traits/PublishableStubTrait.php
+++ b/src/Console/Commands/Traits/PublishableStubTrait.php
@@ -15,10 +15,10 @@ trait PublishableStubTrait
      */
     public function getStubPath(string $path): string
     {
-        if (file_exists(base_path('stubs/backpack/generators/{$stub}.stub'))) {
-            return base_path('stubs/backpack/generators/{$stub}.stub');
+        if (file_exists(base_path("stubs/backpack/generators/{$path}.stub"))) {
+            return base_path("stubs/backpack/generators/{$path}.stub");
         }
 
-        return __DIR__.'/../stubs/{$stub}.stub';
+        return __DIR__.'/../../stubs/{$stub}.stub';
     }
 }

--- a/src/Console/Commands/Traits/PublishableStubTrait.php
+++ b/src/Console/Commands/Traits/PublishableStubTrait.php
@@ -1,12 +1,13 @@
 <?php
 
 namespace Backpack\Generators\Console\Commands\Traits;
+
 use Illuminate\Support\Str;
 
 trait PublishableStubTrait
 {
     /**
-     * Return the path to the stub
+     * Return the path to the stub.
      */
     public function getStubPath(string $path): string
     {

--- a/src/Console/Commands/Traits/PublishableStubTrait.php
+++ b/src/Console/Commands/Traits/PublishableStubTrait.php
@@ -1,23 +1,21 @@
 <?php
 
 namespace Backpack\Generators\Console\Commands\Traits;
+use Illuminate\Support\Str;
 
 trait PublishableStubTrait
 {
     /**
-     * Check if the stub exists in the project's stubs folder.
-     * If it does, return the path to it.
-     * If it doesn't, return the path to the stub in the package.
-     *
-     * @param  string  $path
-     * @return string
+     * Return the path to the stub
      */
     public function getStubPath(string $path): string
     {
-        if (file_exists(base_path("stubs/backpack/generators/{$path}.stub"))) {
-            return base_path("stubs/backpack/generators/{$path}.stub");
+        $path = Str::finish($path, '.stub');
+
+        if (file_exists(base_path("stubs/backpack/generators/{$path}"))) {
+            return base_path("stubs/backpack/generators/{$path}");
         }
 
-        return __DIR__."/../../stubs/{$path}.stub";
+        return __DIR__."/../../stubs/{$path}";
     }
 }

--- a/src/Console/Commands/ViewBackpackCommand.php
+++ b/src/Console/Commands/ViewBackpackCommand.php
@@ -6,6 +6,8 @@ use Illuminate\Console\GeneratorCommand;
 
 class ViewBackpackCommand extends GeneratorCommand
 {
+    use \Backpack\Generators\Console\Commands\Traits\PublishableStubTrait;
+
     /**
      * The console command name.
      *
@@ -42,20 +44,10 @@ class ViewBackpackCommand extends GeneratorCommand
     protected function getStub()
     {
         if ($this->option('plain')) {
-            // check if base_path('stubs/backpack/generators/view-plain.stub') exists, and use that
-            if (file_exists(base_path('stubs/backpack/generators/view-plain.stub'))) {
-                return base_path('stubs/backpack/generators/view-plain.stub');
-            }
-
-            return __DIR__.'/../stubs/view-plain.stub';
+            return $this->getStubPath('view-plain');
         }
 
-        // check if base_path('stubs/backpack/generators/view.stub') exists, and use that
-        if (file_exists(base_path('stubs/backpack/generators/view.stub'))) {
-            return base_path('stubs/backpack/generators/view.stub');
-        }
-
-        return __DIR__.'/../stubs/view.stub';
+        return $this->getStubPath('view');
     }
 
     /**

--- a/src/Console/Commands/ViewBackpackCommand.php
+++ b/src/Console/Commands/ViewBackpackCommand.php
@@ -42,7 +42,17 @@ class ViewBackpackCommand extends GeneratorCommand
     protected function getStub()
     {
         if ($this->option('plain')) {
+            // check if base_path('stubs/backpack/generators/view-plain.stub') exists, and use that
+            if (file_exists(base_path('stubs/backpack/generators/view-plain.stub'))) {
+                return base_path('stubs/backpack/generators/view-plain.stub');
+            }
+
             return __DIR__.'/../stubs/view-plain.stub';
+        }
+
+        // check if base_path('stubs/backpack/generators/view.stub') exists, and use that
+        if (file_exists(base_path('stubs/backpack/generators/view.stub'))) {
+            return base_path('stubs/backpack/generators/view.stub');
         }
 
         return __DIR__.'/../stubs/view.stub';

--- a/src/Console/Commands/Views/PublishOrCreateViewBackpackCommand.php
+++ b/src/Console/Commands/Views/PublishOrCreateViewBackpackCommand.php
@@ -17,6 +17,11 @@ abstract class PublishOrCreateViewBackpackCommand extends GeneratorCommand
      */
     protected function getStub()
     {
+        // check if base_path('stubs/backpack/generators/$FILE') exists, and use that
+        if (file_exists(base_path('stubs/backpack/generators/generators/'.$this->stub))) {
+            return base_path('stubs/backpack/generators/generators/'.$this->stub);
+        }
+
         return __DIR__.'/../../stubs/'.$this->stub;
     }
 

--- a/src/Console/Commands/Views/PublishOrCreateViewBackpackCommand.php
+++ b/src/Console/Commands/Views/PublishOrCreateViewBackpackCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 abstract class PublishOrCreateViewBackpackCommand extends GeneratorCommand
 {
     use \Backpack\CRUD\app\Console\Commands\Traits\PrettyCommandOutput;
+    use \Backpack\Generators\Console\Commands\Traits\PublishableStubTrait;
 
     /**
      * The source file to copy from.
@@ -41,12 +42,7 @@ abstract class PublishOrCreateViewBackpackCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        // check if base_path('stubs/backpack/generators/$FILE') exists, and use that
-        if (file_exists(base_path('stubs/backpack/generators/generators/'.$this->stub))) {
-            return base_path('stubs/backpack/generators/generators/'.$this->stub);
-        }
-
-        return __DIR__.'/../../stubs/'.$this->stub;
+        return $this->getStubPath($this->stub);
     }
 
     /**

--- a/src/GeneratorsServiceProvider.php
+++ b/src/GeneratorsServiceProvider.php
@@ -55,6 +55,6 @@ class GeneratorsServiceProvider extends ServiceProvider
 
         $this->publishes([
             __DIR__.'/Console/stubs' => base_path('stubs/backpack/generators'),
-        ], 'stubs');
+        ], 'backpack-generators-stubs');
     }
 }

--- a/src/GeneratorsServiceProvider.php
+++ b/src/GeneratorsServiceProvider.php
@@ -47,13 +47,21 @@ class GeneratorsServiceProvider extends ServiceProvider
         WidgetBackpackCommand::class,
     ];
 
+    public function boot(): void
+    {
+        $this->offerPublishing();
+        $this->commands($this->commands);
+    }
+
     /**
-     * Register any package services.
+     * Enables publishing stubs.
      *
      * @return void
      */
-    public function register()
+    protected function offerPublishing(): void
     {
-        $this->commands($this->commands);
+        $this->publishes([
+            __DIR__.'/Console/stubs' => base_path('stubs/backpack/generators'),
+        ], 'stubs');
     }
 }

--- a/src/GeneratorsServiceProvider.php
+++ b/src/GeneratorsServiceProvider.php
@@ -49,17 +49,8 @@ class GeneratorsServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        $this->offerPublishing();
         $this->commands($this->commands);
-    }
 
-    /**
-     * Enables publishing stubs.
-     *
-     * @return void
-     */
-    protected function offerPublishing(): void
-    {
         $this->publishes([
             __DIR__.'/Console/stubs' => base_path('stubs/backpack/generators'),
         ], 'stubs');


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

As started in https://github.com/Laravel-Backpack/Generators/pull/188 we didn't allow to publish the stubs.

I picked up the code from that PR a took it to the final stage.

### AFTER - What is happening after this PR?

You can now publish the stubs with `php artisan vendor:publish --tag=backpack-generators-stubs` and the commands will pick either the stub from the user folder, or use the one in the package. 


## HOW

### How did you achieve that, in technical terms?

Shadownbane did almost all the work, all credits goes to him. We added a trait that return the stub path for components. 

### Is it a breaking change or non-breaking change?

No I don't think so.

