### PR TITLE
dont use Str value() function unavailable in Laravel 8

### DIFF
--- a/src/Console/Commands/BuildBackpackCommand.php
+++ b/src/Console/Commands/BuildBackpackCommand.php
@@ -83,8 +83,8 @@ class BuildBackpackCommand extends Command
 
             // Try to load it from file content
             $fileContent = Str::of(file_get_contents($filepath));
-            $namespace = $fileContent->match('/namespace (.*);/')->value();
-            $classname = $fileContent->match('/class (\w+)/')->value();
+            $namespace = (string) $fileContent->match('/namespace (.*);/');
+            $classname = (string) $fileContent->match('/class (\w+)/');
 
             $result = $this->validateModelClass("$namespace\\$classname");
             if ($result) {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We already remove some calls to Str::value() as it's not available in Laravel 8. https://github.com/Laravel-Backpack/Generators/pull/185

This ones were leftovers. https://github.com/Laravel-Backpack/Generators/issues/196

### AFTER - What is happening after this PR?

We no longer use the `Str::value()` function in v3 of generators.