### PR TITLE
update stubs - remove $dates property, use basset, remove array syntax

### DIFF
--- a/src/Console/stubs/crud-controller.stub
+++ b/src/Console/stubs/crud-controller.stub
@@ -56,7 +56,6 @@ class DummyClassCrudController extends CrudController
     protected function setupCreateOperation()
     {
         CRUD::setValidation(DummyClassRequest::class);
-        
         CRUD::setFromDb(); // set fields from db columns.
 
         /**

--- a/src/Console/stubs/crud-controller.stub
+++ b/src/Console/stubs/crud-controller.stub
@@ -39,12 +39,11 @@ class DummyClassCrudController extends CrudController
      */
     protected function setupListOperation()
     {
-        CRUD::setFromDb(); // columns
+        CRUD::setFromDb(); // set columns from db columns.
 
         /**
-         * Columns can be defined using the fluent syntax or array syntax:
+         * Columns can be defined using the fluent syntax:
          * - CRUD::column('price')->type('number');
-         * - CRUD::addColumn(['name' => 'price', 'type' => 'number']); 
          */
     }
 
@@ -57,13 +56,12 @@ class DummyClassCrudController extends CrudController
     protected function setupCreateOperation()
     {
         CRUD::setValidation(DummyClassRequest::class);
-
-        CRUD::setFromDb(); // fields
+        
+        CRUD::setFromDb(); // set fields from db columns.
 
         /**
-         * Fields can be defined using the fluent syntax or array syntax:
+         * Fields can be defined using the fluent syntax:
          * - CRUD::field('price')->type('number');
-         * - CRUD::addField(['name' => 'price', 'type' => 'number'])); 
          */
     }
 

--- a/src/Console/stubs/crud-model.stub
+++ b/src/Console/stubs/crud-model.stub
@@ -23,7 +23,6 @@ class DummyClass extends Model
     protected $guarded = ['id'];
     // protected $fillable = [];
     // protected $hidden = [];
-    // protected $dates = [];
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Console/stubs/field.stub
+++ b/src/Console/stubs/field.stub
@@ -22,25 +22,25 @@
 {{-- CUSTOM CSS --}}
 @push('crud_fields_styles')
     {{-- How to load a CSS file? --}}
-    @loadOnce('dummyFieldStyle.css')
+    @basset(asset('dummyFieldStyle.css'))
 
     {{-- How to add some CSS? --}}
-    @loadOnce('dummy_field_style')
+    @bassetBlock('backpack/crud/fields/dummy_field-style.css')
         <style>
             .dummy_field_class {
                 display: none;
             }
         </style>
-    @endLoadOnce
+    @endBassetBlock
 @endpush
 
 {{-- CUSTOM JS --}}
 @push('crud_fields_scripts')
     {{-- How to load a JS file? --}}
-    @loadOnce('dummyFieldScript.js')
+    @basset(asset('dummyFieldScript.js'))
 
     {{-- How to add some JS to the field? --}}
-    @loadOnce('bpFieldInitDummyFieldElement')
+    @bassetBlock('backpack/crud/fields/dummy_field-script.js')
     <script>
         function bpFieldInitDummyFieldElement(element) {
             // this function will be called on pageload, because it's
@@ -50,5 +50,5 @@
             console.log(element.val());
         }
     </script>
-    @endLoadOnce
+    @endBassetBlock
 @endpush

--- a/src/Console/stubs/field.stub
+++ b/src/Console/stubs/field.stub
@@ -22,7 +22,7 @@
 {{-- CUSTOM CSS --}}
 @push('crud_fields_styles')
     {{-- How to load a CSS file? --}}
-    @basset(asset('dummyFieldStyle.css'))
+    @basset('dummyFieldStyle.css')
 
     {{-- How to add some CSS? --}}
     @bassetBlock('backpack/crud/fields/dummy_field-style.css')
@@ -37,10 +37,10 @@
 {{-- CUSTOM JS --}}
 @push('crud_fields_scripts')
     {{-- How to load a JS file? --}}
-    @basset(asset('dummyFieldScript.js'))
+    @basset('dummyFieldScript.js')
 
     {{-- How to add some JS to the field? --}}
-    @bassetBlock('backpack/crud/fields/dummy_field-script.js')
+    @bassetBlock('path/to/script.js')
     <script>
         function bpFieldInitDummyFieldElement(element) {
             // this function will be called on pageload, because it's

--- a/src/Console/stubs/filter.stub
+++ b/src/Console/stubs/filter.stub
@@ -12,14 +12,6 @@
 {{-- ########################################### --}}
 {{-- Extra CSS and JS for this particular filter --}}
 
-{{-- FILTERS EXTRA CSS --}}
-{{-- push things in the after_styles section --}}
-
-{{-- @push('crud_list_styles')
-	no css
-@endpush --}}
-
-
 {{-- FILTERS EXTRA JS --}}
 {{-- push things in the after_scripts section --}}
 

--- a/src/Console/stubs/model-softdelete.stub
+++ b/src/Console/stubs/model-softdelete.stub
@@ -57,12 +57,6 @@ class DummyClass extends Model
      */
     // protected $hidden = [];
 
-    /**
-     * The attributes that should be mutated to dates.
-     *
-     * @var array
-     */
-    // protected $dates = [];
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Console/stubs/model.stub
+++ b/src/Console/stubs/model.stub
@@ -54,13 +54,6 @@ class DummyClass extends Model
      */
     // protected $hidden = [];
 
-    /**
-     * The attributes that should be mutated to dates.
-     *
-     * @var array
-     */
-    // protected $dates = [];
-
     /*
     |--------------------------------------------------------------------------
     | FUNCTIONS


### PR DESCRIPTION
This is mainly to fix https://github.com/Laravel-Backpack/Generators/issues/193 removing the mention to array syntax

I also removed the `$dates` property from the model, it had been deprecated some time ago https://github.com/laravel/framework/pull/42587

Updated the field stub to use the basset directives ... and stopped or this PR would blow out of scope. 
