### PR TITLE
fix controller generation when field is used as validation source

### DIFF
--- a/src/Console/Commands/CrudControllerBackpackCommand.php
+++ b/src/Console/Commands/CrudControllerBackpackCommand.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Str;
 class CrudControllerBackpackCommand extends BackpackCommand
 {
     use \Backpack\CRUD\app\Console\Commands\Traits\PrettyCommandOutput;
-    use \Backpack\Generators\Console\Commands\Traits\PublishableStubTrait;
+    use Traits\PublishableStubTrait;
 
     /**
      * The console command name.
@@ -223,7 +223,7 @@ class CrudControllerBackpackCommand extends BackpackCommand
 
         // remove the validation class when validation is field
         if ($validation === 'field') {
-            $stub = str_replace("        CRUD::setValidation(DummyClassRequest::class);\n\n", '', $stub);
+            $stub = str_replace('        CRUD::setValidation(DummyClassRequest::class);'.PHP_EOL, '', $stub);
         }
 
         return $this;


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Trying to create a CrudController with `php artisan backpack:crud Something` and choosing the `fields` has the validation source, the command would fail to remove the `setValidation` from the final class, and that would raise errors since the RequestClass is not created when `fields` is chose. 

### AFTER - What is happening after this PR?

It works 🤷‍♂️ 
