### PR TITLE
add option to generate forms without id, use named parameters in formAction

### DIFF
--- a/src/Console/Commands/CrudFormOperationBackpackCommand.php
+++ b/src/Console/Commands/CrudFormOperationBackpackCommand.php
@@ -19,7 +19,7 @@ class CrudFormOperationBackpackCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'backpack:crud-form-operation {name}';
+    protected $signature = 'backpack:crud-form-operation {name} {--no-id}';
 
     /**
      * The console command description.
@@ -71,12 +71,8 @@ class CrudFormOperationBackpackCommand extends GeneratorCommand
 
     /**
      * Replace the table name for the given stub.
-     *
-     * @param  string  $stub
-     * @param  string  $name
-     * @return string
      */
-    protected function replaceNameStrings(&$stub, $name)
+    protected function replaceNameStrings(string &$stub, string $name): self
     {
         $name = Str::of($name)->afterLast('\\');
 
@@ -85,6 +81,11 @@ class CrudFormOperationBackpackCommand extends GeneratorCommand
         $stub = str_replace('Dummy Class', $name->snake()->replace('_', ' ')->title(), $stub);
         $stub = str_replace('dummy-class', $name->snake('-'), $stub);
         $stub = str_replace('dummy_class', $name->snake(), $stub);
+        $stub = str_replace('DUMMY_ROUTE_WITH_ID', $this->option('no-id') ? 'false' : 'true', $stub);
+        $stub = str_replace('DUMMY_BUTTON_STACK', $this->option('no-id') ? 'top' : 'line', $stub);
+        $stub = str_replace('DUMMY_FORM_ACTION_CALLBACK', $this->option('no-id') ? 'formLogic: function ($inputs, $entry) {' : 'id: $id, formLogic: function ($inputs, $entry) {', $stub);
+        $stub = str_replace('DUMMY_FUNCTION_PARAMETERS', $this->option('no-id') ? '' : 'int $id', $stub);
+        $stub = str_replace('DUMMY_GETFORM_VIEW_PARAMETER', $this->option('no-id') ? '' : '$id', $stub);
 
         return $this;
     }

--- a/src/Console/stubs/crud-form-operation.stub
+++ b/src/Console/stubs/crud-form-operation.stub
@@ -19,7 +19,7 @@ trait DummyClassOperation
     {
         $this->formRoutes(
             operationName: 'dummyClass',
-            routesHaveIdSegment: true,
+            routesHaveIdSegment: DUMMY_ROUTE_WITH_ID,
             segment: $segment,
             routeName: $routeName,
             controller: $controller
@@ -33,7 +33,7 @@ trait DummyClassOperation
     {
         $this->formDefaults(
             operationName: 'dummyClass',
-            // buttonStack: 'line', // alternatives: top, bottom
+            buttonStack: 'DUMMY_BUTTON_STACK', // alternatives: top, bottom
             // buttonMeta: [
             //     'icon' => 'la la-home',
             //     'label' => 'Dummy Class',
@@ -48,11 +48,11 @@ trait DummyClassOperation
      * Method to handle the GET request and display the View with a Backpack form
      *
      */
-    public function getDummyClassForm(?int $id = null) : \Illuminate\Contracts\View\View
+    public function getDummyClassForm(DUMMY_FUNCTION_PARAMETERS) : \Illuminate\Contracts\View\View
     {
         $this->crud->hasAccessOrFail('dummyClass');
 
-        return $this->formView($id);
+        return $this->formView(DUMMY_GETFORM_VIEW_PARAMETER);
     }
 
     /**
@@ -60,11 +60,11 @@ trait DummyClassOperation
     *
     * @return array|\Illuminate\Http\RedirectResponse
     */
-    public function postDummyClassForm(?int $id = null)
+    public function postDummyClassForm(DUMMY_FUNCTION_PARAMETERS)
     {
         $this->crud->hasAccessOrFail('dummyClass');
 
-        return $this->formAction($id, function ($inputs, $entry) {
+        return $this->formAction(DUMMY_FORM_ACTION_CALLBACK
             // You logic goes here...
             // dd('got to ' . __METHOD__, $inputs, $entry);
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

I have the need to quickly generate forms that are not using id in routes. 

Even if the "required change" is to make `routesHaveIdSegment: false`, the generated Operation had alot of `$id` references when not needed, so they needed to manually cleaned.


### AFTER - What is happening after this PR?

One can use `--no-id` to generate a form without $id parameter. 

The generated operation files will now on use named parameters on the `formAction` callback. 

This will also help in the fact that we need to do a breaking change in https://github.com/Laravel-Backpack/CRUD/pull/5459 and people generating operations with the commands after this PR will not be affected. 
