### PR TITLE
Update CrudBackpackCommand.php

### DIFF
--- a/src/Console/Commands/CrudBackpackCommand.php
+++ b/src/Console/Commands/CrudBackpackCommand.php
@@ -78,12 +78,14 @@ class CrudBackpackCommand extends BackpackCommand
             $this->call('route:cache');
         }
 
-        $url = Str::of(config('app.url'))->finish('/')
-        ->append(
-        (!empty(config('backpack.base.route_prefix'))
-            ? config('backpack.base.route_prefix') . '/'
-            : '') . $nameKebab
-        );
+        $routePrefix = config('backpack.base.route_prefix');
+        
+        $url = Str::of(config('app.url'))
+            ->finish('/')
+            ->when($routePrefix !== '', function ($string) use ($routePrefix) {
+                return $string->append($routePrefix)->finish('/');
+            })
+            ->append($nameKebab);
 
         $this->newLine();
         $this->line("  Done! Go to <fg=blue>$url</> to see the CRUD in action.");

--- a/src/Console/Commands/CrudBackpackCommand.php
+++ b/src/Console/Commands/CrudBackpackCommand.php
@@ -78,7 +78,12 @@ class CrudBackpackCommand extends BackpackCommand
             $this->call('route:cache');
         }
 
-        $url = Str::of(config('app.url'))->finish('/')->append('admin/')->append($nameKebab);
+        $url = Str::of(config('app.url'))->finish('/')
+        ->append(
+        (!empty(config('backpack.base.route_prefix'))
+            ? config('backpack.base.route_prefix') . '/'
+            : '') . $nameKebab
+        );
 
         $this->newLine();
         $this->line("  Done! Go to <fg=blue>$url</> to see the CRUD in action.");


### PR DESCRIPTION
## WHY

if route prefix is defined, better to get it from backpack route prefix


### BEFORE - What was wrong? What was happening before this PR?

before it was static value with "http://domain.ltd/**admin**/

### AFTER - What is happening after this PR?

now it is dynamic value with whatever being set backpack.base.route_prefix "http://domain.ltd/**defined_path**/

### How did you achieve that, in technical terms?

if route prefix is defined, better to get it from backpack route prefix

### Is it a breaking change or non-breaking change?

no


### How can we test the before & after?

you dont need to :)
