### PR TITLE
Update page stub to closely match backpack pages

### DIFF
--- a/src/Console/stubs/page.stub
+++ b/src/Console/stubs/page.stub
@@ -1,9 +1,18 @@
 @extends(backpack_view('layout'))
 
 @section('content')
-<div class="jumbotron">
-    <h1 class="mb-4">Dummy Name</h1>
-
-    <p>Go to <code>{{ $page }}</code> to edit this view or <code>{{ $controller }}</code> to edit the controller.</p>
-</div>
+<section class="header-operation container-fluid animated fadeIn d-flex mb-2 align-items-baseline d-print-none" bp-section="page-header">
+    <h1 class="text-capitalize mb-0" bp-section="page-heading">Dummy Name</h1>
+    <p class="ms-2 ml-2 mb-0" bp-section="page-subheading">Page for Dummy Name</p>
+</section>
+<section class="content container-fluid animated fadeIn" bp-section="content">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                    Go to <code>{{ $page }}</code> to edit this view or <code>{{ $controller }}</code> to edit the controller.
+                </div>
+            </div>
+        </div>
+    </div>
 @endsection


### PR DESCRIPTION
## WHY

reported by a genius here: https://github.com/Laravel-Backpack/DevTools/issues/350

### BEFORE - What was wrong? What was happening before this PR?

The page stub was fairly basic, and wasn't consistent in all themes/layouts. Additionally developers would have quite a hard time to replicate our pages with the headers and the container. 


### AFTER - What is happening after this PR?

I think it's easier to just remove what you don't need, than trying to figure out how to add this stuff.

![image](https://github.com/user-attachments/assets/8a55892e-56dc-4b1e-8e9c-5445e082007b)
![image](https://github.com/user-attachments/assets/ddc3691d-a1fd-4ade-82b9-2042e326f302)
![image](https://github.com/user-attachments/assets/b51d0c17-b986-4c27-9396-13f9e98b581a)


## HOW

### How did you achieve that, in technical terms?

Changed the stub file.


### Is it a breaking change or non-breaking change?

Non. If developers had the stub published, their custom stub still takes precedence. 

