### PR TITLE
Do not use request if no request validation set

### DIFF
--- a/src/Console/Commands/CrudBackpackCommand.php
+++ b/src/Console/Commands/CrudBackpackCommand.php
@@ -73,7 +73,7 @@ class CrudBackpackCommand extends BackpackCommand
         ]);
 
         // if the application uses cached routes, we should rebuild the cache so the previous added route will
-        // be acessible without manually clearing the route cache.
+        // be accessible without manually clearing the route cache.
         if (app()->routesAreCached()) {
             $this->call('route:cache');
         }

--- a/src/Console/Commands/CrudControllerBackpackCommand.php
+++ b/src/Console/Commands/CrudControllerBackpackCommand.php
@@ -226,9 +226,9 @@ class CrudControllerBackpackCommand extends BackpackCommand
             $stub = str_replace('        CRUD::setValidation(DummyClassRequest::class);'.PHP_EOL, '', $stub);
         }
 
-        if($validation !== 'request') {
+        if ($validation !== 'request') {
             $stub = str_replace('use App\Http\Requests\DummyModelClassRequest;', '', $stub);
-        }else{
+        } else {
             // add a new line after the use statement
             $stub = str_replace('use App\Http\Requests\DummyModelClassRequest;', "use App\Http\Requests\DummyModelClassRequest;\n", $stub);
         }

--- a/src/Console/Commands/CrudControllerBackpackCommand.php
+++ b/src/Console/Commands/CrudControllerBackpackCommand.php
@@ -226,6 +226,13 @@ class CrudControllerBackpackCommand extends BackpackCommand
             $stub = str_replace('        CRUD::setValidation(DummyClassRequest::class);'.PHP_EOL, '', $stub);
         }
 
+        if($validation !== 'request') {
+            $stub = str_replace('use App\Http\Requests\DummyModelClassRequest;', '', $stub);
+        }else{
+            // add a new line after the use statement
+            $stub = str_replace('use App\Http\Requests\DummyModelClassRequest;', "use App\Http\Requests\DummyModelClassRequest;\n", $stub);
+        }
+
         return $this;
     }
 

--- a/src/Console/stubs/crud-controller.stub
+++ b/src/Console/stubs/crud-controller.stub
@@ -2,10 +2,9 @@
 
 namespace DummyNamespace;
 
-use App\Http\Requests\DummyModelClassRequest;
 use Backpack\CRUD\app\Http\Controllers\CrudController;
 use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
-
+use App\Http\Requests\DummyModelClassRequest;
 /**
  * Class DummyClassCrudController
  * @package App\Http\Controllers\Admin


### PR DESCRIPTION
## WHY
fixes: https://github.com/Laravel-Backpack/community-forum/issues/1191
### BEFORE - What was wrong? What was happening before this PR?

When choosing `array` or `field` validation for a crud-controller, the `use Request` statement would still be in the generated class, raising errors as that class is only created when using `request` validation.

### AFTER - What is happening after this PR?

We do not use the request if the validation does not use the request.


## HOW

### How did you achieve that, in technical terms?

replaced some strings in the stub.



### Is it a breaking change or non-breaking change?

non
